### PR TITLE
Arreglo del fichero AppForSEII2526.cs de la carpeta de tests.

### DIFF
--- a/src/AppForSEII2526.API/Models/Review.cs
+++ b/src/AppForSEII2526.API/Models/Review.cs
@@ -9,7 +9,7 @@
 
         public Review(
             int reviewId,
-            int customerId,
+            string customerId,
             int overallRating,
 
             string reviewTitle,
@@ -42,7 +42,7 @@
 
 
         [Required]
-        public int CustomerId { get; set; }
+        public string CustomerId { get; set; }
         [Required]
         [Range(0, 5, ErrorMessage = "La puntuación debe estar entre 0 y 5 estrellas")]
         public int OverallRating { get; set; }

--- a/test/AppForSEII2526.UT/AppForSEII2526.cs
+++ b/test/AppForSEII2526.UT/AppForSEII2526.cs
@@ -1,5 +1,5 @@
 ﻿namespace AppForSEII2526.UT {
-    public class AppForSEII2526SqliteUT
+    public class AppForSEII25264SqliteUT
     {
         protected readonly DbConnection _connection;
         protected readonly ApplicationDbContext _context;
@@ -12,7 +12,7 @@
         //}
 
         void Dispose() => _connection.Dispose();
-        public AppForSEII2526SqliteUT() {
+        public AppForSEII25264SqliteUT() {
             // Create and open a connection. This creates the SQLite in-memory database, which will persist until the connection is closed
             // at the end of the test (see Dispose below).
             _connection = new SqliteConnection("Filename=:memory:");

--- a/test/AppForSEII2526.UT/AppForSEII2526.cs
+++ b/test/AppForSEII2526.UT/AppForSEII2526.cs
@@ -1,5 +1,6 @@
-﻿namespace AppForMovies.UT {
-    public class AppForMovies4SqliteUT {
+﻿namespace AppForSEII2526.UT {
+    public class AppForSEII2526SqliteUT
+    {
         protected readonly DbConnection _connection;
         protected readonly ApplicationDbContext _context;
         protected readonly DbContextOptions<ApplicationDbContext> _contextOptions;
@@ -11,7 +12,7 @@
         //}
 
         void Dispose() => _connection.Dispose();
-        public AppForMovies4SqliteUT() {
+        public AppForSEII2526SqliteUT() {
             // Create and open a connection. This creates the SQLite in-memory database, which will persist until the connection is closed
             // at the end of the test (see Dispose below).
             _connection = new SqliteConnection("Filename=:memory:");


### PR DESCRIPTION
 Con el nuevo cambio del fichero AppForSEII2526.cs de la carpeta UT se resolvión el problema del namespace y nombre de la clase mal definido al corresto para evitar futuros problemas por ambiguedades de nombres.
Se realizó el cambio del namespace y nombre de clase desde **AppForMovies **y** AppForMovies4SQLite **a** AppForSEII2526 **y** AppForSEII25264SQLite** respectivamente