### PR TITLE
fix(api): Añadir descripción opcional a PurchaseItem

### DIFF
--- a/src/AppForSEII2526.API/Migrations/20260428214103_AddDescriptionToPurchaseItem.Designer.cs
+++ b/src/AppForSEII2526.API/Migrations/20260428214103_AddDescriptionToPurchaseItem.Designer.cs
@@ -4,6 +4,7 @@ using AppForSEII2526.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AppForSEII2526.API.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428214103_AddDescriptionToPurchaseItem")]
+    partial class AddDescriptionToPurchaseItem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/AppForSEII2526.API/Migrations/20260428214103_AddDescriptionToPurchaseItem.cs
+++ b/src/AppForSEII2526.API/Migrations/20260428214103_AddDescriptionToPurchaseItem.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AppForSEII2526.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDescriptionToPurchaseItem : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "PurchaseItems",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "PurchaseItems");
+        }
+    }
+}

--- a/src/AppForSEII2526.API/Models/PurchaseItem.cs
+++ b/src/AppForSEII2526.API/Models/PurchaseItem.cs
@@ -14,15 +14,20 @@ namespace AppForSEII2526.API.Models
             if (purchase is null) throw new ArgumentNullException(nameof(purchase));
             if (quantity <= 0) throw new ArgumentOutOfRangeException(nameof(quantity), "Quantity must be > 0.");
 
-            Device = device; DeviceId = device.Id;
-            Purchase = purchase; PurchaseId = purchase.Id;
+            Device = device;
+            DeviceId = device.Id;
+            Purchase = purchase;
+            PurchaseId = purchase.Id;
 
             Price = Convert.ToDecimal(device.priceForPurchase);
             Quantity = quantity;
         }
 
         public PurchaseItem(Device device, decimal unitPrice, int quantity, Purchase purchase)
-            : this(device, quantity, purchase) { Price = unitPrice; }
+            : this(device, quantity, purchase)
+        {
+            Price = unitPrice;
+        }
 
         public Device Device { get; set; } = default!;
         public int DeviceId { get; set; }
@@ -30,9 +35,14 @@ namespace AppForSEII2526.API.Models
         public Purchase Purchase { get; set; } = default!;
         public int PurchaseId { get; set; }
 
-        [Precision(10, 2)] public decimal Price { get; set; }
+        [Precision(10, 2)]
+        public decimal Price { get; set; }
+
         [Range(1, int.MaxValue, ErrorMessage = "You must provide a quantity higher than 0")]
         public int Quantity { get; set; }
+
+        [StringLength(500, ErrorMessage = "Description cannot be longer than 500 characters")]
+        public string? Description { get; set; }
 
         public override bool Equals(object? obj)
         {


### PR DESCRIPTION
Closes #123

## Sprint
_Sprint 1_

## Qué cambia
- Añadida la propiedad opcional `Description` a `PurchaseItem`.
- Añadida migración EF Core para incorporar `Description` en la tabla `PurchaseItems`.

## Cómo se ha probado
- `dotnet ef migrations add AddDescriptionToPurchaseItem --project src\AppForSEII2526.API --startup-project src\AppForSEII2526.API`
- `dotnet build src\AppForSEII2526.API\AppForSEII2526.API.csproj`

## Notas
Este cambio cierra la corrección pendiente del modelo para el CU1 Comprar dispositivo antes de comenzar Sprint 2.