### PR TITLE
feat(api): añadir purchase DTOs

### DIFF
--- a/src/AppForSEII2526.API/DTOs/DeviceDTOs/DeviceForPurchaseDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/DeviceDTOs/DeviceForPurchaseDTO.cs
@@ -1,0 +1,34 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace AppForSEII2526.API.DTOs.DevicesDTO
+{
+    public class DeviceForPurchaseDTO   
+    {
+        public DeviceForPurchaseDTO(int id, string name, double price, string brand, string model, string color)
+        {
+            Id = id;
+            Name = name;
+            Price = price;
+            Brand = brand;
+            Model = model;
+            Color = color;
+        }
+
+        public int Id { get; set; }
+
+        [StringLength(50, ErrorMessage = "Name cannot be longer than 50 characters.", MinimumLength = 1)]
+        public string Name { get; set; }
+
+        [Range(0.0, 1000.0, ErrorMessage = "Price must be between 0 and 1000.")]
+        public double Price { get; set; }
+
+        [StringLength(50, ErrorMessage = "Brand cannot be longer than 50 characters.", MinimumLength = 1)]
+        public string Brand { get; set; }
+
+        [StringLength(50, ErrorMessage = "Model cannot be longer than 50 characters.", MinimumLength = 1)]
+        public string Model { get; set; }
+
+        [StringLength(50, ErrorMessage = "Color cannot be longer than 50 characters.", MinimumLength = 1)]
+        public string Color { get; set; }
+    }
+}

--- a/src/AppForSEII2526.API/DTOs/PurchaseDTOs/PurchaseDetailDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/PurchaseDTOs/PurchaseDetailDTO.cs
@@ -1,0 +1,46 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace AppForSEII2526.API.DTOs.PurchaseDTOs
+{
+    public class PurchaseDetailDTO
+    {
+        public PurchaseDetailDTO(
+            int id,
+            string name,
+            string surname,
+            string deliveryAddress,
+            DateTime purchaseDateUtc,
+            double totalPrice,
+            int totalQuantity,
+            IList<PurchaseItemDTO> purchaseItems)
+        {
+            Id = id;
+            Name = name;
+            Surname = surname;
+            DeliveryAddress = deliveryAddress;
+            PurchaseDateUtc = purchaseDateUtc;
+            TotalPrice = totalPrice;
+            TotalQuantity = totalQuantity;
+            PurchaseItems = purchaseItems;
+        }
+
+        public int Id { get; set; }
+
+        [StringLength(50)]
+        public string Name { get; set; }
+
+        [StringLength(100)]
+        public string Surname { get; set; }
+
+        [StringLength(200)]
+        public string DeliveryAddress { get; set; }
+
+        public DateTime PurchaseDateUtc { get; set; }
+
+        public double TotalPrice { get; set; }
+
+        public int TotalQuantity { get; set; }
+
+        public IList<PurchaseItemDTO> PurchaseItems { get; set; }
+    }
+}

--- a/src/AppForSEII2526.API/DTOs/PurchaseDTOs/PurchaseForCreateDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/PurchaseDTOs/PurchaseForCreateDTO.cs
@@ -1,0 +1,45 @@
+﻿using AppForSEII2526.API.Models;
+using System.ComponentModel.DataAnnotations;
+
+namespace AppForSEII2526.API.DTOs.PurchaseDTOs
+{
+    public class PurchaseForCreateDTO
+    {
+        public PurchaseForCreateDTO(
+            string customerUserName,
+            string name,
+            string surname,
+            string deliveryAddress,
+            PaymentMethod paymentMethod,
+            IList<PurchaseItemDTO> purchaseItems)
+        {
+            CustomerUserName = customerUserName;
+            Name = name;
+            Surname = surname;
+            DeliveryAddress = deliveryAddress;
+            PaymentMethod = paymentMethod;
+            PurchaseItems = purchaseItems;
+        }
+
+        [Required]
+        public string CustomerUserName { get; set; }
+
+        [Required]
+        [StringLength(50, MinimumLength = 2)]
+        public string Name { get; set; }
+
+        [Required]
+        [StringLength(100, MinimumLength = 2)]
+        public string Surname { get; set; }
+
+        [Required]
+        [StringLength(200, MinimumLength = 5)]
+        public string DeliveryAddress { get; set; }
+
+        [Required]
+        public PaymentMethod PaymentMethod { get; set; }
+
+        [Required]
+        public IList<PurchaseItemDTO> PurchaseItems { get; set; }
+    }
+}

--- a/src/AppForSEII2526.API/DTOs/PurchaseDTOs/PurchaseItemDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/PurchaseDTOs/PurchaseItemDTO.cs
@@ -1,0 +1,37 @@
+﻿using System.ComponentModel.DataAnnotations;
+namespace AppForSEII2526.API.DTOs.PurchaseDTOs
+{
+    public class PurchaseItemDTO
+    {
+        public PurchaseItemDTO(int deviceId, string brand, string model, string color, decimal price, int quantity, string? description)
+        {
+            DeviceId = deviceId;
+            Brand = brand;
+            Model = model;
+            Color = color;
+            Price = price;
+            Quantity = quantity;
+            Description = description;
+        }
+
+        public int DeviceId { get; set; }
+
+        [StringLength(50)]
+        public string Brand { get; set; }
+
+        [StringLength(50)]
+        public string Model { get; set; }
+
+        [StringLength(50)]
+        public string Color { get; set; }
+
+        [Range(0.0, 1000.0)]
+        public decimal Price { get; set; }
+
+        [Range(1, int.MaxValue, ErrorMessage = "You must provide a quantity higher than 0")]
+        public int Quantity { get; set; }
+
+        [StringLength(500)]
+        public string? Description { get; set; }
+    }
+}


### PR DESCRIPTION
Closes #125
Closes #126
Closes #127
Closes #128

## Sprint
Sprint 2

## Qué cambia
- Añadido `DeviceForPurchaseDTO`.
- Añadido `PurchaseItemDTO`.
- Añadido `PurchaseForCreateDTO`.
- Añadido `PurchaseDetailDTO`.

## Cómo se ha probado
- `dotnet build src\AppForSEII2526.API\AppForSEII2526.API.csproj`

## Relación
- Implementa parcialmente #11.
- Implementa parcialmente #12.
- Implementa parcialmente #13.
- Implementa parcialmente #14.
- Relacionado con la épica #10.