### PR TITLE
feat(api): Añadir devices for purchase endpoint

### DIFF
--- a/src/AppForSEII2526.API/Controllers/DeviceController.cs
+++ b/src/AppForSEII2526.API/Controllers/DeviceController.cs
@@ -1,4 +1,5 @@
 ﻿using AppForSEII2526.API.DTOs.DeviceDTOs.DevideRentalDTOs;
+using AppForSEII2526.API.DTOs.DevicesDTO;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Net;
@@ -93,6 +94,43 @@ namespace AppForSEII2526.API.Controllers
                     d.Model.NameModel,
                     d.Color,
                     d.Brand))
+                .ToListAsync();
+
+            return Ok(devices);
+        }
+
+        [HttpGet]
+        [Route("[action]")]
+        [ProducesResponseType(typeof(IList<DeviceForPurchaseDTO>), (int)HttpStatusCode.OK)]
+        public async Task<ActionResult<IList<DeviceForPurchaseDTO>>> GetDevicesForPurchase(
+            string? name,
+            string? color)
+        {
+            if (!string.IsNullOrEmpty(name))
+                name = name.Trim().ToLower();
+
+            if (!string.IsNullOrEmpty(color))
+                color = color.Trim().ToLower();
+
+            var query = _context.Device
+                .Include(d => d.Model)
+                .Where(d => d.quantityForPurchase > 0);
+
+            if (!string.IsNullOrWhiteSpace(name))
+                query = query.Where(d => d.Name.ToLower().Contains(name));
+
+            if (!string.IsNullOrWhiteSpace(color))
+                query = query.Where(d => d.Color.ToLower().Contains(color));
+
+            var devices = await query
+                .OrderBy(d => d.Name)
+                .Select(d => new DeviceForPurchaseDTO(
+                    d.Id,
+                    d.Name,
+                    d.priceForPurchase,
+                    d.Brand,
+                    d.Model.NameModel,
+                    d.Color))
                 .ToListAsync();
 
             return Ok(devices);

--- a/src/AppForSEII2526.API/Controllers/DeviceController.cs
+++ b/src/AppForSEII2526.API/Controllers/DeviceController.cs
@@ -1,5 +1,5 @@
 ﻿using AppForSEII2526.API.DTOs.DeviceDTOs.DevideRentalDTOs;
-using AppForSEII2526.API.DTOs.DevicesDTO;
+using AppForSEII2526.API.DTOs.DeviceDTOs;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Net;

--- a/src/AppForSEII2526.API/DTOs/DeviceDTOs/DeviceForPurchaseDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/DeviceDTOs/DeviceForPurchaseDTO.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace AppForSEII2526.API.DTOs.DevicesDTO
+namespace AppForSEII2526.API.DTOs.DeviceDTOs
 {
     public class DeviceForPurchaseDTO   
     {


### PR DESCRIPTION
Closes #129

## Sprint
Sprint 2

## Qué cambia
- Añadido endpoint `GetDevicesForPurchase`.
- Permite filtrar dispositivos por nombre.
- Permite filtrar dispositivos por color.
- Devuelve una lista de `DeviceForPurchaseDTO`.
- Solo devuelve dispositivos con stock disponible para compra.

## Cómo se ha probado
- `dotnet build src\AppForSEII2526.API\AppForSEII2526.API.csproj`

## Relación
- Implementa #11.
- Relacionado con la épica #10.