### PR TITLE
fix(api): separar nombre y apellidos en Purchase

### DIFF
--- a/src/AppForSEII2526.API/Migrations/20260430194652_FixPurchaseCustomerName.Designer.cs
+++ b/src/AppForSEII2526.API/Migrations/20260430194652_FixPurchaseCustomerName.Designer.cs
@@ -4,6 +4,7 @@ using AppForSEII2526.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AppForSEII2526.API.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430194652_FixPurchaseCustomerName")]
+    partial class FixPurchaseCustomerName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/AppForSEII2526.API/Migrations/20260430194652_FixPurchaseCustomerName.cs
+++ b/src/AppForSEII2526.API/Migrations/20260430194652_FixPurchaseCustomerName.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AppForSEII2526.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixPurchaseCustomerName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CustomerNameSurname",
+                table: "Purchases");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Name",
+                table: "Purchases",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Surname",
+                table: "Purchases",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Name",
+                table: "Purchases");
+
+            migrationBuilder.DropColumn(
+                name: "Surname",
+                table: "Purchases");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CustomerNameSurname",
+                table: "Purchases",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/src/AppForSEII2526.API/Models/Purchase.cs
+++ b/src/AppForSEII2526.API/Models/Purchase.cs
@@ -9,7 +9,8 @@ namespace AppForSEII2526.API.Models
 
         public Purchase(
             string customerUserName,
-            string customerNameSurname,
+            string name,
+            string surname,
             ApplicationUser applicationUser,
             string deliveryAddress,
             DateTime purchaseDateUtc,
@@ -19,7 +20,8 @@ namespace AppForSEII2526.API.Models
             ApplicationUser = applicationUser ?? throw new ArgumentNullException(nameof(applicationUser));
 
             CustomerUserName = customerUserName;
-            CustomerNameSurname = customerNameSurname;
+            Name = name;
+            Surname = surname;
             DeliveryAddress = deliveryAddress;
             PurchaseDateUtc = purchaseDateUtc;
             Items = items ?? new List<PurchaseItem>();
@@ -31,13 +33,14 @@ namespace AppForSEII2526.API.Models
         public Purchase(
             int id,
             string customerUserName,
-            string customerNameSurname,
+            string name,
+            string surname,
             ApplicationUser applicationUser,
             string deliveryAddress,
             DateTime purchaseDateUtc,
             IList<PurchaseItem> items,
             PaymentMethod paymentMethod)
-            : this(customerUserName, customerNameSurname, applicationUser, deliveryAddress, purchaseDateUtc, items, paymentMethod)
+            : this(customerUserName, name, surname, applicationUser, deliveryAddress, purchaseDateUtc, items, paymentMethod)
         {
             Id = id;
         }
@@ -45,8 +48,9 @@ namespace AppForSEII2526.API.Models
         [Key] public int Id { get; set; }
 
         [Required] public string CustomerUserName { get; set; } = string.Empty;
-        [Required] public string CustomerNameSurname { get; set; } = string.Empty;
-
+        [Required, MaxLength(50)] public string Name { get; set; } = string.Empty;
+        [Required, MaxLength(50)] public string Surname { get; set; } = string.Empty;
+  
         [Required] public string ApplicationUserId { get; set; } = string.Empty;
 
         public ApplicationUser ApplicationUser { get; set; } = default!;


### PR DESCRIPTION
Closes #138 

## Sprint
Sprint 2

## Qué cambia
- Separados los campos `Name` y `Surname` en `Purchase`.
- Eliminado `CustomerNameSurname` para evitar duplicidad de datos.
- Añadida migración EF Core correspondiente.

## Cómo se ha probado
- `dotnet build src\AppForSEII2526.API\AppForSEII2526.API.csproj`

## Relación
- Relacionado con #13.
- Relacionado con #14.
- Relacionado con la épica #10.