### PR TITLE
feat(api): añadir PurchasesController

### DIFF
--- a/src/AppForSEII2526.API/Controllers/PurchasesController.cs
+++ b/src/AppForSEII2526.API/Controllers/PurchasesController.cs
@@ -59,5 +59,100 @@ namespace AppForSEII2526.API.Controllers
 
             return Ok(purchaseDetail);
         }
+
+        [HttpPost]
+        [Route("[action]")]
+        [ProducesResponseType(typeof(PurchaseDetailDTO), (int)HttpStatusCode.Created)]
+        [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType((int)HttpStatusCode.NotFound)]
+        [ProducesResponseType((int)HttpStatusCode.Conflict)]
+        public async Task<ActionResult<PurchaseDetailDTO>> CreatePurchase([FromBody] PurchaseForCreateDTO purchaseForCreate)
+        {
+            var user = await _context.Users
+                .FirstOrDefaultAsync(au => au.UserName == purchaseForCreate.CustomerUserName);
+
+            if (user == null)
+            {
+                ModelState.AddModelError(
+                    "PurchaseApplicationUser",
+                    "Error! Usuario no registrado");
+
+                return BadRequest(new ValidationProblemDetails(ModelState));
+            }
+
+            var purchase = new Purchase(
+                purchaseForCreate.CustomerUserName,
+                purchaseForCreate.Name,
+                purchaseForCreate.Surname,
+                user,
+                purchaseForCreate.DeliveryAddress,
+                DateTime.UtcNow,
+                new List<PurchaseItem>(),
+                purchaseForCreate.PaymentMethod
+            );
+
+            foreach (var item in purchaseForCreate.PurchaseItems)
+            {
+                var device = await _context.Device
+                    .Include(d => d.Model)
+                    .FirstOrDefaultAsync(d => d.Id == item.DeviceId);
+
+                if (device == null)
+                {
+                    _logger.LogWarning("El dispositivo con id {DeviceId} no existe", item.DeviceId);
+                    return NotFound();
+                }
+
+                var purchaseItem = new PurchaseItem(
+                    device,
+                    item.Price,
+                    item.Quantity,
+                    purchase)
+                {
+                    Description = item.Description
+                };
+
+                purchase.Items.Add(purchaseItem);
+            }
+
+            purchase.TotalPrice = purchase.Items.Sum(pi => pi.Price * pi.Quantity);
+            purchase.TotalQuantity = purchase.Items.Sum(pi => pi.Quantity);
+
+            _context.Purchases.Add(purchase);
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error al guardar la compra");
+                return Conflict("Error al guardar la compra: " + ex.Message);
+            }
+
+            var purchaseDetail = new PurchaseDetailDTO(
+                purchase.Id,
+                purchase.Name,
+                purchase.Surname,
+                purchase.DeliveryAddress,
+                purchase.PurchaseDateUtc,
+                Convert.ToDouble(purchase.TotalPrice),
+                purchase.TotalQuantity,
+                purchase.Items.Select(pi => new PurchaseItemDTO(
+                    pi.DeviceId,
+                    pi.Device.Brand,
+                    pi.Device.Model.NameModel,
+                    pi.Device.Color,
+                    pi.Price,
+                    pi.Quantity,
+                    pi.Description
+                )).ToList()
+            );
+
+            return CreatedAtAction(
+                nameof(GetPurchase),
+                new { id = purchase.Id },
+                purchaseDetail);
+        }
     }
 }

--- a/src/AppForSEII2526.API/Controllers/PurchasesController.cs
+++ b/src/AppForSEII2526.API/Controllers/PurchasesController.cs
@@ -1,0 +1,63 @@
+﻿using AppForSEII2526.API.DTOs.PurchaseDTOs;
+using AppForSEII2526.API.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Net;
+
+namespace AppForSEII2526.API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PurchasesController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly ILogger<PurchasesController> _logger;
+
+        public PurchasesController(ApplicationDbContext context, ILogger<PurchasesController> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        [Route("[action]")]
+        [ProducesResponseType(typeof(PurchaseDetailDTO), (int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.NotFound)]
+        public async Task<ActionResult<PurchaseDetailDTO>> GetPurchase(int id)
+        {
+            var purchase = await _context.Purchases
+                .Include(p => p.ApplicationUser)
+                .Include(p => p.Items)
+                    .ThenInclude(pi => pi.Device)
+                        .ThenInclude(d => d.Model)
+                .FirstOrDefaultAsync(p => p.Id == id);
+
+            if (purchase == null)
+            {
+                _logger.LogWarning("Compra con id {PurchaseId} no existe", id);
+                return NotFound();
+            }
+
+            var purchaseDetail = new PurchaseDetailDTO(
+                purchase.Id,
+                purchase.Name,
+                purchase.Surname,
+                purchase.DeliveryAddress,
+                purchase.PurchaseDateUtc,
+                Convert.ToDouble(purchase.TotalPrice),
+                purchase.TotalQuantity,
+                purchase.Items.Select(pi => new PurchaseItemDTO(
+                    pi.DeviceId,
+                    pi.Device.Brand,
+                    pi.Device.Model.NameModel,
+                    pi.Device.Color,
+                    pi.Price,
+                    pi.Quantity,
+                    pi.Description
+                )).ToList()
+            );
+
+            return Ok(purchaseDetail);
+        }
+    }
+}


### PR DESCRIPTION
Closes #130

## Sprint
Sprint 2

## Qué cambia
- Añadido `PurchasesController`.
- Añadido endpoint `GetPurchase`.
- Añadido endpoint `CreatePurchase`.
- Se persisten `Purchase` y `PurchaseItems`.
- Se calculan `TotalPrice` y `TotalQuantity`.
- Se devuelve `CreatedAtAction` al crear correctamente la compra.

## Cómo se ha probado
- `dotnet build src\AppForSEII2526.API\AppForSEII2526.API.csproj`

## Relación
- Implementa parcialmente #13.
- Implementa parcialmente #14.
- Relacionado con la épica #10.