### PR TITLE
test(api): añadir UTs de Purchase

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.420",
+    "rollForward": "latestFeature"
+  }
+}

--- a/test/AppForSEII2526.UT/DevicesController_test/GetDevicesForPurchase_test.cs
+++ b/test/AppForSEII2526.UT/DevicesController_test/GetDevicesForPurchase_test.cs
@@ -1,0 +1,154 @@
+﻿using AppForMovies.UT;
+using AppForSEII2526.API.Controllers;
+using AppForSEII2526.API.DTOs.DeviceDTOs;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AppForSEII2526.UT.DevicesController_test
+{
+    public class GetDevicesForPurchase_test : AppForSEII25264SqliteUT
+    {
+        public GetDevicesForPurchase_test()
+        {
+            var models = new List<Model>()
+            {
+                new Model(1, "NVIDIA GeForce RTX 5090"),
+                new Model(2, "NVIDIA GeForce RTX 5080"),
+                new Model(3, "NVIDIA GeForce RTX 4080 Ti"),
+                new Model(4, "AMD Radeon RX 7900")
+            };
+
+            var devices = new List<Device>()
+            {
+                new Device(1, 2025, QualityType.Hight, 3, 5, 59.99, 2199.99,
+                    "RTX 5090 Founders Edition", "Negro", "NVIDIA",
+                    "Máximo rendimiento en gaming 8K y tareas de IA",
+                    models[0], new List<RentDevice>(), new List<ReviewItem>(), new List<PurchaseItem>()),
+
+                new Device(2, 2025, QualityType.Medium, 8, 22, 49.99, 1699.99,
+                    "RTX 5080 Gaming Pro", "Plata", "MSI",
+                    "Ideal para gaming 4K con DLSS 4.0",
+                    models[1], new List<RentDevice>(), new List<ReviewItem>(), new List<PurchaseItem>()),
+
+                new Device(3, 2025, QualityType.Low, 6, 12, 39.99, 1299.99,
+                    "RTX 4080 Ti Dual Fan", "Blanco", "Gigabyte",
+                    "Excelente rendimiento en 1440p y eficiencia térmica",
+                    models[2], new List<RentDevice>(), new List<ReviewItem>(), new List<PurchaseItem>()),
+
+                new Device(4, 2025, QualityType.MediumHight, 5, 0, 64.99, 2299.99,
+                    "RTX 5090 OC Edition", "Negro/Rojo", "ASUS",
+                    "Versión overclockeada con triple ventilador",
+                    models[0], new List<RentDevice>(), new List<ReviewItem>(), new List<PurchaseItem>()),
+
+                new Device(5, 2025, QualityType.Medium, 4, 7, 44.99, 1199.99,
+                    "Radeon RX 7900 XT", "Negro", "AMD",
+                    "GPU AMD de alto rendimiento",
+                    models[3], new List<RentDevice>(), new List<ReviewItem>(), new List<PurchaseItem>())
+            };
+
+            _context.AddRange(models);
+            _context.AddRange(devices);
+            _context.SaveChanges();
+        }
+
+        public static IEnumerable<object[]> TestCasesFor_GetDevicesForPurchase_OK()
+        {
+            var dispositivos = new List<DeviceForPurchaseDTO>()
+    {
+        new DeviceForPurchaseDTO(3, "RTX 4080 Ti Dual Fan", 1299.99, "Gigabyte", "NVIDIA GeForce RTX 4080 Ti", "Blanco"),
+        new DeviceForPurchaseDTO(2, "RTX 5080 Gaming Pro", 1699.99, "MSI", "NVIDIA GeForce RTX 5080", "Plata"),
+        new DeviceForPurchaseDTO(1, "RTX 5090 Founders Edition", 2199.99, "NVIDIA", "NVIDIA GeForce RTX 5090", "Negro"),
+        new DeviceForPurchaseDTO(5, "Radeon RX 7900 XT", 1199.99, "AMD", "AMD Radeon RX 7900", "Negro")
+    };
+
+            return new List<object[]>
+    {
+        // Sin filtros: devuelve todos los dispositivos con stock de compra > 0.
+        new object[]
+        {
+            null,
+            null,
+            dispositivos
+        },
+
+        // Filtro por nombre.
+        new object[]
+        {
+            "5090",
+            null,
+            dispositivos.Where(d => d.Name.Contains("5090")).ToList()
+        },
+
+        // Filtro por color.
+        new object[]
+        {
+            null,
+            "negro",
+            dispositivos.Where(d => d.Color.ToLower().Contains("negro")).ToList()
+        },
+
+        // Filtros combinados.
+        new object[]
+        {
+            "RTX",
+            "blanco",
+            dispositivos.Where(d => d.Name.Contains("RTX") && d.Color.ToLower().Contains("blanco")).ToList()
+        },
+
+        // Sin resultados.
+        new object[]
+        {
+            "NoExiste",
+            null,
+            new List<DeviceForPurchaseDTO>()
+        }
+    };
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCasesFor_GetDevicesForPurchase_OK))]
+        [Trait("Database", "WithoutFixture")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task GetDevicesForPurchase_OK_test(
+            string? name,
+            string? color,
+            IList<DeviceForPurchaseDTO> dispositivosEsperados)
+        {
+            var logger = new Mock<ILogger<DeviceController>>();
+            var controller = new DeviceController(_context, logger.Object);
+
+            var result = await controller.GetDevicesForPurchase(name, color);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var retornoControlador = Assert.IsType<List<DeviceForPurchaseDTO>>(okResult.Value);
+
+            Assert.Equal(dispositivosEsperados, retornoControlador, new DeviceForPurchaseDTOComparer());
+        }
+
+        private class DeviceForPurchaseDTOComparer : IEqualityComparer<DeviceForPurchaseDTO>
+        {
+            public bool Equals(DeviceForPurchaseDTO? x, DeviceForPurchaseDTO? y)
+            {
+                if (x == null || y == null) return false;
+
+                return x.Id == y.Id &&
+                       x.Name == y.Name &&
+                       Math.Abs(x.Price - y.Price) < 0.01 &&
+                       x.Brand == y.Brand &&
+                       x.Model == y.Model &&
+                       x.Color == y.Color;
+            }
+
+            public int GetHashCode(DeviceForPurchaseDTO obj)
+            {
+                return HashCode.Combine(obj.Id, obj.Name, obj.Price, obj.Brand, obj.Model, obj.Color);
+            }
+        }
+    }
+}

--- a/test/AppForSEII2526.UT/PurchaseController_test/GetPurchase_test.cs
+++ b/test/AppForSEII2526.UT/PurchaseController_test/GetPurchase_test.cs
@@ -1,0 +1,128 @@
+﻿using AppForMovies.UT;
+using AppForSEII2526.API.Controllers;
+using AppForSEII2526.API.DTOs.PurchaseDTOs;
+using AppForSEII2526.API.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AppForSEII2526.UT.PurchasesController_test
+{
+    public class GetPurchase_test : AppForSEII25264SqliteUT
+    {
+        private readonly Purchase _purchase;
+
+        public GetPurchase_test()
+        {
+            var model = new Model(1, "NVIDIA GeForce RTX 5090");
+
+            var device = new Device(
+                1,
+                2025,
+                QualityType.Hight,
+                3,
+                5,
+                59.99,
+                999.99,
+                "RTX 5090 Founders Edition",
+                "Negro",
+                "NVIDIA",
+                "Máximo rendimiento en gaming 8K y tareas de IA",
+                model,
+                new List<RentDevice>(),
+                new List<ReviewItem>(),
+                new List<PurchaseItem>()
+            );
+
+            var user = new ApplicationUser("1", "Maria", "Diaz", "maria@uclm.es")
+            {
+                UserName = "maria@uclm.es",
+                Email = "maria@uclm.es"
+            };
+
+            _purchase = new Purchase(
+                1,
+                "maria@uclm.es",
+                "Maria",
+                "Diaz",
+                user,
+                "Calle Luna 45",
+                new DateTime(2026, 5, 5, 10, 0, 0, DateTimeKind.Utc),
+                new List<PurchaseItem>(),
+                PaymentMethod.CreditCard
+            );
+
+            var purchaseItem = new PurchaseItem(
+                device,
+                999.99m,
+                2,
+                _purchase)
+            {
+                Description = device.Description
+            };
+
+            _purchase.Items.Add(purchaseItem);
+            _purchase.TotalPrice = 1999.98m;
+            _purchase.TotalQuantity = 2;
+
+            _context.Add(user);
+            _context.Add(model);
+            _context.Add(device);
+            _context.Add(_purchase);
+            _context.SaveChanges();
+        }
+
+        [Fact]
+        [Trait("Database", "WithoutFixture")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task GetPurchase_OK_test()
+        {
+            var controller = new PurchasesController(
+                _context,
+                new Mock<ILogger<PurchasesController>>().Object);
+
+            var result = await controller.GetPurchase(_purchase.Id);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var purchaseDetail = Assert.IsType<PurchaseDetailDTO>(okResult.Value);
+
+            Assert.Equal(_purchase.Id, purchaseDetail.Id);
+            Assert.Equal("Maria", purchaseDetail.Name);
+            Assert.Equal("Diaz", purchaseDetail.Surname);
+            Assert.Equal("Calle Luna 45", purchaseDetail.DeliveryAddress);
+            Assert.Equal(_purchase.PurchaseDateUtc, purchaseDetail.PurchaseDateUtc);
+            Assert.Equal(1999.98, purchaseDetail.TotalPrice, 2);
+            Assert.Equal(2, purchaseDetail.TotalQuantity);
+
+            Assert.Single(purchaseDetail.PurchaseItems);
+
+            var item = purchaseDetail.PurchaseItems.First();
+            Assert.Equal(1, item.DeviceId);
+            Assert.Equal("NVIDIA", item.Brand);
+            Assert.Equal("NVIDIA GeForce RTX 5090", item.Model);
+            Assert.Equal("Negro", item.Color);
+            Assert.Equal(999.99m, item.Price);
+            Assert.Equal(2, item.Quantity);
+            Assert.Equal("Máximo rendimiento en gaming 8K y tareas de IA", item.Description);
+        }
+
+        [Fact]
+        [Trait("Database", "WithoutFixture")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task GetPurchase_NotFound_test()
+        {
+            var controller = new PurchasesController(
+                _context,
+                new Mock<ILogger<PurchasesController>>().Object);
+
+            var result = await controller.GetPurchase(999);
+
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+    }
+}

--- a/test/AppForSEII2526.UT/PurchaseController_test/PostPurchase_test.cs
+++ b/test/AppForSEII2526.UT/PurchaseController_test/PostPurchase_test.cs
@@ -1,0 +1,277 @@
+﻿using AppForMovies.UT;
+using AppForSEII2526.API.Controllers;
+using AppForSEII2526.API.DTOs.PurchaseDTOs;
+using AppForSEII2526.API.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AppForSEII2526.UT.PurchasesController_test
+{
+    public class PostPurchase_test : AppForSEII25264SqliteUT
+    {
+        private readonly ApplicationUser _user;
+        private readonly Device _deviceWithStock;
+        private readonly Device _deviceWithoutEnoughStock;
+
+        public PostPurchase_test()
+        {
+            var models = new List<Model>()
+            {
+                new Model(1, "NVIDIA GeForce RTX 5090"),
+                new Model(2, "NVIDIA GeForce RTX 5080")
+            };
+
+            _deviceWithStock = new Device(
+                1,
+                2025,
+                QualityType.Hight,
+                3,
+                5,
+                59.99,
+                999.99,
+                "RTX 5090 Founders Edition",
+                "Negro",
+                "NVIDIA",
+                "Máximo rendimiento en gaming 8K y tareas de IA",
+                models[0],
+                new List<RentDevice>(),
+                new List<ReviewItem>(),
+                new List<PurchaseItem>()
+            );
+
+            _deviceWithoutEnoughStock = new Device(
+                2,
+                2025,
+                QualityType.Medium,
+                8,
+                1,
+                49.99,
+                799.99,
+                "RTX 5080 Gaming Pro",
+                "Plata",
+                "MSI",
+                "Ideal para gaming 4K con DLSS 4.0",
+                models[1],
+                new List<RentDevice>(),
+                new List<ReviewItem>(),
+                new List<PurchaseItem>()
+            );
+
+            _user = new ApplicationUser("1", "Maria", "Diaz", "maria@uclm.es")
+            {
+                UserName = "maria@uclm.es",
+                Email = "maria@uclm.es"
+            };
+
+            _context.Add(_user);
+            _context.AddRange(models);
+            _context.Add(_deviceWithStock);
+            _context.Add(_deviceWithoutEnoughStock);
+            _context.SaveChanges();
+        }
+
+        [Fact]
+        [Trait("Database", "WithoutFixture")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task CreatePurchase_OK_test()
+        {
+            var controller = new PurchasesController(
+                _context,
+                new Mock<ILogger<PurchasesController>>().Object);
+
+            var purchaseForCreate = new PurchaseForCreateDTO(
+                "maria@uclm.es",
+                "Maria",
+                "Diaz",
+                "Calle Luna 45",
+                PaymentMethod.CreditCard,
+                new List<PurchaseItemDTO>
+                {
+                    new PurchaseItemDTO(
+                        _deviceWithStock.Id,
+                        _deviceWithStock.Brand,
+                        _deviceWithStock.Model.NameModel,
+                        _deviceWithStock.Color,
+                        999.99m,
+                        2,
+                        _deviceWithStock.Description)
+                });
+
+            var result = await controller.CreatePurchase(purchaseForCreate);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
+            Assert.Equal(nameof(PurchasesController.GetPurchase), createdResult.ActionName);
+
+            var purchaseDetail = Assert.IsType<PurchaseDetailDTO>(createdResult.Value);
+
+            Assert.Equal("Maria", purchaseDetail.Name);
+            Assert.Equal("Diaz", purchaseDetail.Surname);
+            Assert.Equal("Calle Luna 45", purchaseDetail.DeliveryAddress);
+            Assert.Equal(1999.98, purchaseDetail.TotalPrice, 2);
+            Assert.Equal(2, purchaseDetail.TotalQuantity);
+            Assert.Single(purchaseDetail.PurchaseItems);
+
+            var item = purchaseDetail.PurchaseItems.First();
+            Assert.Equal(_deviceWithStock.Id, item.DeviceId);
+            Assert.Equal("NVIDIA", item.Brand);
+            Assert.Equal("NVIDIA GeForce RTX 5090", item.Model);
+            Assert.Equal("Negro", item.Color);
+            Assert.Equal(999.99m, item.Price);
+            Assert.Equal(2, item.Quantity);
+
+            Assert.Single(_context.Purchases);
+            Assert.Single(_context.PurchaseItems);
+        }
+
+        public static IEnumerable<object[]> TestCasesFor_CreatePurchase_BadRequest()
+        {
+            yield return new object[]
+            {
+                new PurchaseForCreateDTO(
+                    "maria@uclm.es",
+                    "Maria",
+                    "Diaz",
+                    "Calle Luna 45",
+                    PaymentMethod.CreditCard,
+                    new List<PurchaseItemDTO>()),
+                "PurchaseItems"
+            };
+
+            yield return new object[]
+            {
+                new PurchaseForCreateDTO(
+                    "noexiste@uclm.es",
+                    "Maria",
+                    "Diaz",
+                    "Calle Luna 45",
+                    PaymentMethod.CreditCard,
+                    new List<PurchaseItemDTO>
+                    {
+                        new PurchaseItemDTO(
+                            1,
+                            "NVIDIA",
+                            "NVIDIA GeForce RTX 5090",
+                            "Negro",
+                            999.99m,
+                            1,
+                            "Descripción")
+                    }),
+                "PurchaseApplicationUser"
+            };
+
+            yield return new object[]
+            {
+                new PurchaseForCreateDTO(
+                    "maria@uclm.es",
+                    "Maria",
+                    "Diaz",
+                    "",
+                    PaymentMethod.CreditCard,
+                    new List<PurchaseItemDTO>
+                    {
+                        new PurchaseItemDTO(
+                            1,
+                            "NVIDIA",
+                            "NVIDIA GeForce RTX 5090",
+                            "Negro",
+                            999.99m,
+                            1,
+                            "Descripción")
+                    }),
+                "DeliveryAddress"
+            };
+
+            yield return new object[]
+            {
+                new PurchaseForCreateDTO(
+                    "maria@uclm.es",
+                    "Maria",
+                    "Diaz",
+                    "Calle Luna 45",
+                    PaymentMethod.Cash,
+                    new List<PurchaseItemDTO>
+                    {
+                        new PurchaseItemDTO(
+                            1,
+                            "NVIDIA",
+                            "NVIDIA GeForce RTX 5090",
+                            "Negro",
+                            999.99m,
+                            1,
+                            "Descripción")
+                    }),
+                "PaymentMethod"
+            };
+
+            yield return new object[]
+            {
+                new PurchaseForCreateDTO(
+                    "maria@uclm.es",
+                    "Maria",
+                    "Diaz",
+                    "Calle Luna 45",
+                    PaymentMethod.CreditCard,
+                    new List<PurchaseItemDTO>
+                    {
+                        new PurchaseItemDTO(
+                            1,
+                            "NVIDIA",
+                            "NVIDIA GeForce RTX 5090",
+                            "Negro",
+                            999.99m,
+                            0,
+                            "Descripción")
+                    }),
+                "Quantity"
+            };
+
+            yield return new object[]
+            {
+                new PurchaseForCreateDTO(
+                    "maria@uclm.es",
+                    "Maria",
+                    "Diaz",
+                    "Calle Luna 45",
+                    PaymentMethod.CreditCard,
+                    new List<PurchaseItemDTO>
+                    {
+                        new PurchaseItemDTO(
+                            2,
+                            "MSI",
+                            "NVIDIA GeForce RTX 5080",
+                            "Plata",
+                            799.99m,
+                            5,
+                            "Descripción")
+                    }),
+                "Stock"
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCasesFor_CreatePurchase_BadRequest))]
+        [Trait("Database", "WithoutFixture")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task CreatePurchase_BadRequest_test(
+            PurchaseForCreateDTO purchaseForCreate,
+            string expectedErrorKey)
+        {
+            var controller = new PurchasesController(
+                _context,
+                new Mock<ILogger<PurchasesController>>().Object);
+
+            var result = await controller.CreatePurchase(purchaseForCreate);
+
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
+            var validationProblem = Assert.IsType<ValidationProblemDetails>(badRequestResult.Value);
+
+            Assert.Contains(expectedErrorKey, validationProblem.Errors.Keys);
+        }
+    }
+}


### PR DESCRIPTION
Closes #133
Closes #134
Closes #135

## Sprint
Sprint 2

## Qué cambia
- Añadidas UT de `GetDevicesForPurchase`.
- Añadidas UT de `GetPurchase`.
- Añadidas UT de `CreatePurchase`.
- Añadido `global.json` para fijar el SDK .NET 8 del proyecto.

## Cómo se ha probado
- `dotnet test test\AppForSEII2526.UT\AppForSEII2526.UT.csproj`

## Relación
- Verifica #11.
- Verifica #13.
- Verifica #14.
- Verifica #15.
- Relacionado con la épica #10.