### PR TITLE
feat(web): crear PurchaseStateContainer

### DIFF
--- a/src/AppForSEII2526.Web/Program.cs
+++ b/src/AppForSEII2526.Web/Program.cs
@@ -40,6 +40,8 @@ builder.Services.AddSingleton<IEmailSender<ApplicationUser>, IdentityNoOpEmailSe
 builder.Services.AddScoped<ReviewStateContainer>();
 //incorporacion de RentalStateContainer
 builder.Services.AddScoped<RentalStateContainer>();
+//incorporacion de PurchaseStateContainer
+builder.Services.AddScoped<PurchaseStateContainer>();
 //incorporacion del clientAPI
 builder.Services.AddHttpClient(); // Registra el HttpClientFactory
 

--- a/src/AppForSEII2526.Web/PurchaseStateContainer.cs
+++ b/src/AppForSEII2526.Web/PurchaseStateContainer.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using AppForSEII2526.Web.API;
+
+namespace AppForSEII2526.Web;
+
+public class PurchaseStateContainer
+{
+    public IList<PurchaseItemDTO> PurchaseItems { get; private set; } = new List<PurchaseItemDTO>();
+
+    public string? CustomerUserName { get; set; }
+    public string? Name { get; set; }
+    public string? Surname { get; set; }
+    public string? DeliveryAddress { get; set; }
+    public PaymentMethod PaymentMethod { get; set; } = PaymentMethod.CreditCard;
+
+    public event Action? OnChange;
+
+    public bool HasItems => PurchaseItems.Any();
+
+    public double TotalPrice => PurchaseItems.Sum(item => item.Price * item.Quantity);
+
+    public int TotalQuantity => PurchaseItems.Sum(item => item.Quantity);
+
+    public bool ContainsDevice(int deviceId)
+    {
+        return PurchaseItems.Any(item => item.DeviceId == deviceId);
+    }
+
+    public void AddDevice(DeviceForPurchaseDTO device)
+    {
+        var existingItem = PurchaseItems.FirstOrDefault(item => item.DeviceId == device.Id);
+
+        if (existingItem is not null)
+        {
+            existingItem.Quantity++;
+        }
+        else
+        {
+            PurchaseItems.Add(new PurchaseItemDTO
+            {
+                DeviceId = device.Id,
+                Brand = device.Brand,
+                Model = device.Model,
+                Color = device.Color,
+                Price = device.Price,
+                Quantity = 1,
+                Description = string.Empty
+            });
+        }
+
+        NotifyStateChanged();
+    }
+
+    public void RemoveDevice(int deviceId)
+    {
+        var item = PurchaseItems.FirstOrDefault(item => item.DeviceId == deviceId);
+
+        if (item is not null)
+        {
+            PurchaseItems.Remove(item);
+            NotifyStateChanged();
+        }
+    }
+
+    public void UpdateQuantity(int deviceId, int quantity)
+    {
+        var item = PurchaseItems.FirstOrDefault(item => item.DeviceId == deviceId);
+
+        if (item is not null)
+        {
+            item.Quantity = Math.Max(1, quantity);
+            NotifyStateChanged();
+        }
+    }
+
+    public void UpdateDescription(int deviceId, string? description)
+    {
+        var item = PurchaseItems.FirstOrDefault(item => item.DeviceId == deviceId);
+
+        if (item is not null)
+        {
+            item.Description = description;
+            NotifyStateChanged();
+        }
+    }
+
+    public PurchaseForCreateDTO ToPurchaseForCreateDTO()
+    {
+        return new PurchaseForCreateDTO
+        {
+            CustomerUserName = CustomerUserName ?? string.Empty,
+            Name = Name ?? string.Empty,
+            Surname = Surname ?? string.Empty,
+            DeliveryAddress = DeliveryAddress ?? string.Empty,
+            PaymentMethod = PaymentMethod,
+            PurchaseItems = PurchaseItems.ToList()
+        };
+    }
+
+    public void Clear()
+    {
+        PurchaseItems.Clear();
+        CustomerUserName = null;
+        Name = null;
+        Surname = null;
+        DeliveryAddress = null;
+        PaymentMethod = PaymentMethod.CreditCard;
+
+        NotifyStateChanged();
+    }
+
+    private void NotifyStateChanged() => OnChange?.Invoke();
+}


### PR DESCRIPTION
Closes #145

## Sprint

Sprint 3

## Qué cambia

- Añadido `PurchaseStateContainer`.
- Añadida gestión del carrito de compra.
- Añadida lógica para añadir dispositivos al carrito.
- Añadida lógica para eliminar dispositivos del carrito.
- Añadida lógica para actualizar cantidad.
- Añadida lógica para actualizar descripción opcional.
- Añadido cálculo de precio total.
- Añadido cálculo de cantidad total.
- Añadida conservación de datos del formulario de compra:
  - `CustomerUserName`
  - `Name`
  - `Surname`
  - `DeliveryAddress`
  - `PaymentMethod`
- Añadido método para convertir el estado actual a `PurchaseForCreateDTO`.
- Registrado `PurchaseStateContainer` como servicio scoped en `Program.cs`.

## Cómo se ha probado

- `dotnet build src\AppForSEII2526.Web\AppForSEII2526.Web.csproj`

## Relación

- Implementa parcialmente US2 – Añadir al carrito con cantidad y descripción #12.
- Implementa parcialmente US5 – Manejo de alternativos #15.
- Relacionado con la épica Como cliente quiero comprar un dispositivo electrónico para tenerlo en propiedad #10.