### PR TITLE
feat(web): mejorar filtros y carrito de compra

### DIFF
--- a/src/AppForSEII2526.Web/Components/Pages/Purchase/SelectDevicesForPurchase.razor
+++ b/src/AppForSEII2526.Web/Components/Pages/Purchase/SelectDevicesForPurchase.razor
@@ -75,7 +75,7 @@ else
                         <button id="@($"deviceToBuy_{device.Name}")"
                                 class="btn btn-success"
                                 @onclick="() => AddDeviceToCart(device)">
-                            Añadir
+                            @(PurchaseState.ContainsDevice(device.Id) ? "Añadir otro" : "Añadir")
                         </button>
                     </td>
                 </tr>
@@ -91,7 +91,7 @@ else
 @if (!PurchaseState.HasItems)
 {
     <p id="emptyCartMessage" class="text-muted">
-        El carrito está vacío.
+        Añade al menos un dispositivo al carrito para continuar con la compra.
     </p>
 }
 else
@@ -162,6 +162,7 @@ else
 <button id="purchaseDevicesButton"
         class="btn btn-primary"
         disabled="@(!PurchaseState.HasItems)"
+        title="@GetPurchaseButtonTitle()"
         @onclick="ContinuePurchase">
     Comprar dispositivos
 </button>
@@ -218,10 +219,19 @@ else
 
     private void ContinuePurchase()
     {
-        if (PurchaseState.HasItems)
+        if (!PurchaseState.HasItems)
         {
-            Navigation.NavigateTo("/purchase/createpurchase");
+            return;
         }
+
+        Navigation.NavigateTo("/purchase/createpurchase");
+    }
+
+    private string GetPurchaseButtonTitle()
+    {
+        return PurchaseState.HasItems
+            ? "Continuar con la compra"
+            : "Añade al menos un dispositivo al carrito para continuar";
     }
 
     public void Dispose()

--- a/src/AppForSEII2526.Web/Components/Pages/Purchase/SelectDevicesForPurchase.razor
+++ b/src/AppForSEII2526.Web/Components/Pages/Purchase/SelectDevicesForPurchase.razor
@@ -23,8 +23,16 @@
            placeholder="Buscar por color" />
 </div>
 
-<button class="btn btn-primary mb-3" @onclick="SearchDevices">
+<button id="searchDevicesButton"
+        class="btn btn-primary mb-3"
+        @onclick="SearchDevices">
     Buscar
+</button>
+
+<button id="clearDeviceFiltersButton"
+        class="btn btn-secondary mb-3 ms-2"
+        @onclick="ClearFilters">
+    Limpiar filtros
 </button>
 
 @if (IsLoading)
@@ -152,7 +160,15 @@ else
 
         try
         {
-            Devices = await ApiClient.GetDevicesForPurchaseAsync(DeviceNameFilter, ColorFilter);
+            var name = string.IsNullOrWhiteSpace(DeviceNameFilter)
+                ? null
+                : DeviceNameFilter.Trim();
+
+            var color = string.IsNullOrWhiteSpace(ColorFilter)
+                ? null
+                : ColorFilter.Trim();
+
+            Devices = await ApiClient.GetDevicesForPurchaseAsync(name, color);
         }
         catch (Exception ex)
         {
@@ -185,5 +201,12 @@ else
     public void Dispose()
     {
         PurchaseState.OnChange -= StateHasChanged;
+    }
+
+    private async Task ClearFilters()
+    {
+        DeviceNameFilter = null;
+        ColorFilter = null;
+        await SearchDevices();
     }
 }

--- a/src/AppForSEII2526.Web/Components/Pages/Purchase/SelectDevicesForPurchase.razor
+++ b/src/AppForSEII2526.Web/Components/Pages/Purchase/SelectDevicesForPurchase.razor
@@ -90,31 +90,54 @@ else
 
 @if (!PurchaseState.HasItems)
 {
-    <p>El carrito está vacío.</p>
+    <p id="emptyCartMessage" class="text-muted">
+        El carrito está vacío.
+    </p>
 }
 else
 {
     <div id="showPurchaseCart">
-        <table class="table">
+        <table id="PurchaseCartTable" class="table">
             <thead>
                 <tr>
                     <th>Marca</th>
                     <th>Modelo</th>
                     <th>Color</th>
-                    <th>Precio</th>
+                    <th>Precio unitario</th>
                     <th>Cantidad</th>
+                    <th>Subtotal</th>
                     <th>Eliminar</th>
                 </tr>
             </thead>
             <tbody>
                 @foreach (var item in PurchaseState.PurchaseItems)
                 {
-                    <tr>
+                    <tr id="@($"PurchaseCartItem_{item.DeviceId}")">
                         <td>@item.Brand</td>
                         <td>@item.Model</td>
                         <td>@item.Color</td>
                         <td>@item.Price.ToString("0.00") €</td>
-                        <td>@item.Quantity</td>
+                        <td>
+                            <button id="@($"decreaseQuantity_{item.DeviceId}")"
+                                    class="btn btn-outline-secondary btn-sm"
+                                    disabled="@(item.Quantity <= 1)"
+                                    @onclick="() => DecreaseQuantity(item.DeviceId)">
+                                -
+                            </button>
+
+                            <span id="@($"PurchaseItemQuantity_{item.DeviceId}")" class="mx-2">
+                                @item.Quantity
+                            </span>
+
+                            <button id="@($"increaseQuantity_{item.DeviceId}")"
+                                    class="btn btn-outline-secondary btn-sm"
+                                    @onclick="() => IncreaseQuantity(item.DeviceId)">
+                                +
+                            </button>
+                        </td>
+                        <td id="@($"PurchaseItemSubtotal_{item.DeviceId}")">
+                            @((item.Price * item.Quantity).ToString("0.00")) €
+                        </td>
                         <td>
                             <button id="@($"removeDevice_{item.DeviceId}")"
                                     class="btn btn-danger"
@@ -127,12 +150,15 @@ else
             </tbody>
         </table>
 
-        <p id="totalAmount">
+        <p id="cartTotalQuantity">
+            Cantidad total: @PurchaseState.TotalQuantity
+        </p>
+
+        <p id="cartTotalPrice">
             Total: @PurchaseState.TotalPrice.ToString("0.00") €
         </p>
     </div>
 }
-
 <button id="purchaseDevicesButton"
         class="btn btn-primary"
         disabled="@(!PurchaseState.HasItems)"
@@ -208,5 +234,25 @@ else
         DeviceNameFilter = null;
         ColorFilter = null;
         await SearchDevices();
+    }
+
+    private void IncreaseQuantity(int deviceId)
+    {
+        var item = PurchaseState.PurchaseItems.FirstOrDefault(item => item.DeviceId == deviceId);
+
+        if (item is not null)
+        {
+            PurchaseState.UpdateQuantity(deviceId, item.Quantity + 1);
+        }
+    }
+
+    private void DecreaseQuantity(int deviceId)
+    {
+        var item = PurchaseState.PurchaseItems.FirstOrDefault(item => item.DeviceId == deviceId);
+
+        if (item is not null && item.Quantity > 1)
+        {
+            PurchaseState.UpdateQuantity(deviceId, item.Quantity - 1);
+        }
     }
 }


### PR DESCRIPTION
Closes #147
Closes #148
Closes #149

## Sprint

Sprint 3

## Qué cambia

- Refinada la funcionalidad de filtros en `SelectDevicesForPurchase`.
- Mejorado el tratamiento de filtros vacíos antes de llamar a la API.
- Añadido `Trim()` para evitar búsquedas incorrectas por espacios.
- Añadido botón para limpiar filtros.
- Mejorado el mensaje cuando no hay dispositivos que coincidan con los filtros.
- Mejorada la tabla del carrito de compra.
- Añadido subtotal por cada dispositivo seleccionado.
- Añadido cálculo visible de la cantidad total del carrito.
- Añadido cálculo visible del precio total del carrito.
- Añadidos botones para aumentar y disminuir la cantidad de cada dispositivo seleccionado.
- Bloqueada la disminución de cantidad cuando el valor es 1.
- Añadido recalculo automático del subtotal y del total al añadir, eliminar, aumentar o disminuir cantidades.
- Mejorado el flujo alternativo de carrito vacío.
- El botón `Comprar dispositivos` permanece visible aunque el carrito esté vacío.
- El botón queda deshabilitado cuando no hay dispositivos en el carrito.
- Añadido mensaje claro para indicar que debe añadirse al menos un dispositivo antes de continuar.
- Añadido `title` informativo al botón.
- Reforzada la navegación para que `ContinuePurchase` no navegue a `CreatePurchase` si el carrito está vacío.
- Añadidos IDs estables para futuras pruebas funcionales:
  - `searchDevices`
  - `selectColor`
  - `searchDevicesButton`
  - `clearDeviceFiltersButton`
  - `TableOfDevices`
  - `noDevicesMessage`
  - `showPurchaseCart`
  - `PurchaseCartTable`
  - `PurchaseCartItem_{deviceId}`
  - `PurchaseItemQuantity_{deviceId}`
  - `PurchaseItemSubtotal_{deviceId}`
  - `increaseQuantity_{deviceId}`
  - `decreaseQuantity_{deviceId}`
  - `cartTotalQuantity`
  - `cartTotalPrice`
  - `purchaseDevicesButton`
  - `emptyCartMessage`

## Cómo se ha probado

- `dotnet build src\AppForSEII2526.Web\AppForSEII2526.Web.csproj`
- Prueba manual de `/purchase/selectdevicesforpurchase`.
- Prueba manual con dispositivos temporales en base de datos local.
- Prueba manual con filtro por nombre.
- Prueba manual con filtro por color.
- Prueba manual con filtro combinado por nombre y color.
- Prueba manual de búsqueda sin filtros.
- Prueba manual de caso sin resultados.
- Prueba manual del botón para limpiar filtros.
- Prueba manual de añadir dispositivos al carrito.
- Prueba manual de añadir el mismo dispositivo varias veces.
- Prueba manual de aumentar y disminuir cantidades desde el carrito.
- Prueba manual de recalculo de subtotal, cantidad total y precio total.
- Prueba manual de eliminar dispositivos del carrito.
- Prueba manual del botón de compra deshabilitado con carrito vacío.
- Prueba manual del botón de compra habilitado con carrito no vacío.

## Relación

- Implementa US1 – Listar y filtrar dispositivos #11.
- Implementa parcialmente US2 – Añadir al carrito con cantidad y descripción #12.
- Implementa parcialmente US5 – Manejo de alternativos #15.
- Relacionado con la épica Como cliente quiero comprar un dispositivo electrónico para tenerlo en propiedad #10.