### PR TITLE
Task69-Creación de pruebas unitarias para el CU Reparación

### DIFF
--- a/test/AppForSEII2526.UT/ReceiptsController_test/GetReceipt_test.cs
+++ b/test/AppForSEII2526.UT/ReceiptsController_test/GetReceipt_test.cs
@@ -1,0 +1,108 @@
+﻿using AppForMovies.UT;
+using AppForSEII2526.API.Controllers;
+using AppForSEII2526.API.DTOs.RepairDTOs;
+using AppForSEII2526.API.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AppForSEII2526.UT.ReceiptsController_test
+{
+    public class GetReceipt_test : AppForSEII25264SqliteUT
+    {
+        private readonly Receipt _receipt;
+        private readonly Repair _repair;
+
+        public GetReceipt_test()
+        {
+            var scale = new Scale("Básica") { Id = 1 };
+
+            _repair = new Repair("Cambio de pantalla", "Sustitución de pantalla rota", 89.99m, scale.Id)
+            {
+                Id = 1,
+                Scale = scale
+            };
+
+            var user = new ApplicationUser("1", "Maria", "Diaz", "maria@uclm.es")
+            {
+                UserName = "maria@uclm.es",
+                Email = "maria@uclm.es"
+            };
+
+            _context.Add(user);
+            _context.Add(scale);
+            _context.Add(_repair);
+            _context.SaveChanges();
+
+            _receipt = new Receipt(
+                "Maria Diaz",
+                "Calle Luna 45",
+                PaymentMethodTypes.PayPal,
+                new DateTime(2026, 5, 14, 10, 0, 0, DateTimeKind.Utc),
+                89.99m,
+                user);
+
+            var receiptItem = new ReceiptItem
+            {
+                Model = "iPhone 13",
+                RepairId = _repair.Id,
+                Repair = _repair,
+                Receipt = _receipt
+            };
+
+            _receipt.ReceiptItems.Add(receiptItem);
+
+            _context.Add(_receipt);
+            _context.SaveChanges();
+        }
+
+        [Fact]
+        [Trait("Database", "WithoutFixture")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task GetReceipt_OK_test()
+        {
+            var controller = new ReceiptsController(
+                _context,
+                new Mock<ILogger<ReceiptsController>>().Object);
+
+            var result = await controller.GetReceipt(_receipt.Id);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var receiptDetail = Assert.IsType<ReceiptDetailDTO>(okResult.Value);
+
+            Assert.Equal(_receipt.Id, receiptDetail.Id);
+            Assert.Equal("Maria Diaz", receiptDetail.CustomerNameSurname);
+            Assert.Equal("Calle Luna 45", receiptDetail.DeliveryAddress);
+            Assert.Equal(PaymentMethodTypes.PayPal, receiptDetail.PaymentMethod);
+            Assert.Equal(89.99m, receiptDetail.TotalPrice);
+            Assert.Single(receiptDetail.ReceiptItems);
+
+            var item = receiptDetail.ReceiptItems.First();
+
+            Assert.Equal("iPhone 13", item.Model);
+            Assert.Equal(_repair.Id, item.RepairId);
+            Assert.Equal("Cambio de pantalla", item.RepairName);
+            Assert.Equal("Sustitución de pantalla rota", item.RepairDescription);
+            Assert.Equal(89.99m, item.RepairCost);
+            Assert.Equal("Básica", item.Scale);
+        }
+
+        [Fact]
+        [Trait("Database", "WithoutFixture")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task GetReceipt_NotFound_test()
+        {
+            var controller = new ReceiptsController(
+                _context,
+                new Mock<ILogger<ReceiptsController>>().Object);
+
+            var result = await controller.GetReceipt(999);
+
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+    }
+}

--- a/test/AppForSEII2526.UT/ReceiptsController_test/GetRepairsForReceipt_test.cs
+++ b/test/AppForSEII2526.UT/ReceiptsController_test/GetRepairsForReceipt_test.cs
@@ -1,0 +1,122 @@
+﻿using AppForMovies.UT;
+using AppForSEII2526.API.Controllers;
+using AppForSEII2526.API.DTOs.RepairDTOs;
+using AppForSEII2526.API.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AppForSEII2526.UT.ReceiptsController_test
+{
+    public class GetRepairsForReceipt_test : AppForSEII25264SqliteUT
+    {
+        public GetRepairsForReceipt_test()
+        {
+            var basicScale = new Scale("Básica") { Id = 1 };
+            var mediumScale = new Scale("Media") { Id = 2 };
+            var luxuryScale = new Scale("Lujo") { Id = 3 };
+
+            var repairs = new List<Repair>
+            {
+                new Repair("Cambio de pantalla", "Sustitución de pantalla rota", 89.99m, basicScale.Id)
+                {
+                    Id = 1,
+                    Scale = basicScale
+                },
+                new Repair("Cambio de batería", "Sustitución de batería degradada", 49.99m, mediumScale.Id)
+                {
+                    Id = 2,
+                    Scale = mediumScale
+                },
+                new Repair("Reparación placa base", "Reparación avanzada de placa base", 149.99m, luxuryScale.Id)
+                {
+                    Id = 3,
+                    Scale = luxuryScale
+                }
+            };
+
+            _context.AddRange(basicScale, mediumScale, luxuryScale);
+            _context.AddRange(repairs);
+            _context.SaveChanges();
+        }
+
+        [Fact]
+        [Trait("Database", "WithoutFixture")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task GetRepairsForReceipt_OK_test()
+        {
+            var controller = new ReceiptsController(
+                _context,
+                new Mock<ILogger<ReceiptsController>>().Object);
+
+            var result = await controller.GetRepairsForReceipt(null, null);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var repairs = Assert.IsAssignableFrom<IList<RepairForReceiptDTO>>(okResult.Value);
+
+            Assert.Equal(3, repairs.Count);
+            Assert.Contains(repairs, r => r.Name == "Cambio de pantalla");
+            Assert.Contains(repairs, r => r.Name == "Cambio de batería");
+            Assert.Contains(repairs, r => r.Name == "Reparación placa base");
+        }
+
+        [Fact]
+        [Trait("Database", "WithoutFixture")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task GetRepairsForReceipt_FilterByName_OK_test()
+        {
+            var controller = new ReceiptsController(
+                _context,
+                new Mock<ILogger<ReceiptsController>>().Object);
+
+            var result = await controller.GetRepairsForReceipt("pantalla", null);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var repairs = Assert.IsAssignableFrom<IList<RepairForReceiptDTO>>(okResult.Value);
+
+            Assert.Single(repairs);
+            Assert.Equal("Cambio de pantalla", repairs.First().Name);
+            Assert.Equal("Básica", repairs.First().Scale);
+        }
+
+        [Fact]
+        [Trait("Database", "WithoutFixture")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task GetRepairsForReceipt_FilterByScale_OK_test()
+        {
+            var controller = new ReceiptsController(
+                _context,
+                new Mock<ILogger<ReceiptsController>>().Object);
+
+            var result = await controller.GetRepairsForReceipt(null, "lujo");
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var repairs = Assert.IsAssignableFrom<IList<RepairForReceiptDTO>>(okResult.Value);
+
+            Assert.Single(repairs);
+            Assert.Equal("Reparación placa base", repairs.First().Name);
+            Assert.Equal("Lujo", repairs.First().Scale);
+        }
+
+        [Fact]
+        [Trait("Database", "WithoutFixture")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task GetRepairsForReceipt_NoResults_OK_test()
+        {
+            var controller = new ReceiptsController(
+                _context,
+                new Mock<ILogger<ReceiptsController>>().Object);
+
+            var result = await controller.GetRepairsForReceipt("altavoz", null);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var repairs = Assert.IsAssignableFrom<IList<RepairForReceiptDTO>>(okResult.Value);
+
+            Assert.Empty(repairs);
+        }
+    }
+}

--- a/test/AppForSEII2526.UT/ReceiptsController_test/PostReceipt_test.cs
+++ b/test/AppForSEII2526.UT/ReceiptsController_test/PostReceipt_test.cs
@@ -1,0 +1,203 @@
+﻿using AppForMovies.UT;
+using AppForSEII2526.API.Controllers;
+using AppForSEII2526.API.DTOs.RepairDTOs;
+using AppForSEII2526.API.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AppForSEII2526.UT.ReceiptsController_test
+{
+    public class PostReceipt_test : AppForSEII25264SqliteUT
+    {
+        private readonly ApplicationUser _user;
+        private readonly Repair _screenRepair;
+        private readonly Repair _batteryRepair;
+
+        public PostReceipt_test()
+        {
+            var basicScale = new Scale("Básica") { Id = 1 };
+            var mediumScale = new Scale("Media") { Id = 2 };
+
+            _screenRepair = new Repair("Cambio de pantalla", "Sustitución de pantalla rota", 89.99m, basicScale.Id)
+            {
+                Id = 1,
+                Scale = basicScale
+            };
+
+            _batteryRepair = new Repair("Cambio de batería", "Sustitución de batería degradada", 49.99m, mediumScale.Id)
+            {
+                Id = 2,
+                Scale = mediumScale
+            };
+
+            _user = new ApplicationUser("1", "Maria", "Diaz", "maria@uclm.es")
+            {
+                UserName = "maria@uclm.es",
+                Email = "maria@uclm.es"
+            };
+
+            _context.Add(_user);
+            _context.AddRange(basicScale, mediumScale);
+            _context.AddRange(_screenRepair, _batteryRepair);
+            _context.SaveChanges();
+        }
+
+        [Fact]
+        [Trait("Database", "WithoutFixture")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task CreateReceipt_OK_test()
+        {
+            var controller = new ReceiptsController(
+                _context,
+                new Mock<ILogger<ReceiptsController>>().Object);
+
+            var receiptForCreate = new ReceiptForCreateDTO(
+                "maria@uclm.es",
+                "Maria Diaz",
+                "Calle Luna 45",
+                PaymentMethodTypes.CreditCard,
+                new List<ReceiptItemForCreateDTO>
+                {
+                    new ReceiptItemForCreateDTO("iPhone 13", _screenRepair.Id),
+                    new ReceiptItemForCreateDTO("Samsung S22", _batteryRepair.Id)
+                });
+
+            var result = await controller.CreateReceipt(receiptForCreate);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
+            Assert.Equal(nameof(ReceiptsController.GetReceipt), createdResult.ActionName);
+
+            var receiptDetail = Assert.IsType<ReceiptDetailDTO>(createdResult.Value);
+
+            Assert.Equal("Maria Diaz", receiptDetail.CustomerNameSurname);
+            Assert.Equal("Calle Luna 45", receiptDetail.DeliveryAddress);
+            Assert.Equal(PaymentMethodTypes.CreditCard, receiptDetail.PaymentMethod);
+            Assert.Equal(139.98m, receiptDetail.TotalPrice);
+            Assert.Equal(2, receiptDetail.ReceiptItems.Count);
+
+            Assert.Contains(receiptDetail.ReceiptItems, item =>
+                item.Model == "iPhone 13" &&
+                item.RepairName == "Cambio de pantalla" &&
+                item.RepairCost == 89.99m &&
+                item.Scale == "Básica");
+
+            Assert.Contains(receiptDetail.ReceiptItems, item =>
+                item.Model == "Samsung S22" &&
+                item.RepairName == "Cambio de batería" &&
+                item.RepairCost == 49.99m &&
+                item.Scale == "Media");
+
+            Assert.Single(_context.Receipts);
+            Assert.Equal(2, _context.ReceiptItems.Count());
+        }
+
+        public static IEnumerable<object[]> TestCasesFor_CreateReceipt_BadRequest()
+        {
+            yield return new object[]
+            {
+                new ReceiptForCreateDTO(
+                    "maria@uclm.es",
+                    "Maria Diaz",
+                    "Calle Luna 45",
+                    PaymentMethodTypes.CreditCard,
+                    new List<ReceiptItemForCreateDTO>()),
+                "ReceiptItems"
+            };
+
+            yield return new object[]
+            {
+                new ReceiptForCreateDTO(
+                    "noexiste@uclm.es",
+                    "Maria Diaz",
+                    "Calle Luna 45",
+                    PaymentMethodTypes.CreditCard,
+                    new List<ReceiptItemForCreateDTO>
+                    {
+                        new ReceiptItemForCreateDTO("iPhone 13", 1)
+                    }),
+                "ReceiptApplicationUser"
+            };
+
+            yield return new object[]
+            {
+                new ReceiptForCreateDTO(
+                    "maria@uclm.es",
+                    "Maria Diaz",
+                    "",
+                    PaymentMethodTypes.CreditCard,
+                    new List<ReceiptItemForCreateDTO>
+                    {
+                        new ReceiptItemForCreateDTO("iPhone 13", 1)
+                    }),
+                "DeliveryAddress"
+            };
+
+            yield return new object[]
+            {
+                new ReceiptForCreateDTO(
+                    "maria@uclm.es",
+                    "Maria Diaz",
+                    "Calle Luna 45",
+                    PaymentMethodTypes.CreditCard,
+                    new List<ReceiptItemForCreateDTO>
+                    {
+                        new ReceiptItemForCreateDTO("", 1)
+                    }),
+                "Model"
+            };
+
+            yield return new object[]
+            {
+                new ReceiptForCreateDTO(
+                    "maria@uclm.es",
+                    "Maria Diaz",
+                    "Calle Luna 45",
+                    PaymentMethodTypes.CreditCard,
+                    new List<ReceiptItemForCreateDTO>
+                    {
+                        new ReceiptItemForCreateDTO("iPhone 13", 999)
+                    }),
+                "Repair"
+            };
+
+            yield return new object[]
+            {
+                new ReceiptForCreateDTO(
+                    "maria@uclm.es",
+                    "Maria Diaz",
+                    "Calle Luna 45",
+                    (PaymentMethodTypes)99,
+                    new List<ReceiptItemForCreateDTO>
+                    {
+                        new ReceiptItemForCreateDTO("iPhone 13", 1)
+                    }),
+                "PaymentMethod"
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(TestCasesFor_CreateReceipt_BadRequest))]
+        [Trait("Database", "WithoutFixture")]
+        [Trait("LevelTesting", "Unit Testing")]
+        public async Task CreateReceipt_BadRequest_test(
+            ReceiptForCreateDTO receiptForCreate,
+            string expectedErrorKey)
+        {
+            var controller = new ReceiptsController(
+                _context,
+                new Mock<ILogger<ReceiptsController>>().Object);
+
+            var result = await controller.CreateReceipt(receiptForCreate);
+
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
+            var validationProblem = Assert.IsType<ValidationProblemDetails>(badRequestResult.Value);
+
+            Assert.Contains(expectedErrorKey, validationProblem.Errors.Keys);
+        }
+    }
+}


### PR DESCRIPTION
Añadidas pruebas unitarias para el caso de uso Contratar reparación.

Incluye:
- Tests de GetRepairsForReceipt
- Tests de CreateReceipt
- Tests de GetReceipt

Closes #69