### PR TITLE
Task 66-Correción en la clase ReceiptItem #66

### DIFF
--- a/src/AppForSEII2526.API/Models/ReceiptItem.cs
+++ b/src/AppForSEII2526.API/Models/ReceiptItem.cs
@@ -7,10 +7,9 @@ namespace AppForSEII2526.API.Models
     {
         public ReceiptItem() { }
 
-        public ReceiptItem(string model, int receiptId, int repairId)
+        public ReceiptItem(string model, int repairId)
         {
             Model = model;
-            ReceiptId = receiptId;
             RepairId = repairId;
         }
 


### PR DESCRIPTION
Corrige el constructor de ReceiptItem eliminando receiptId como parámetro, ya que la relación con Receipt se asigna mediante EF Core.

Closes #66