### PR TITLE
Task154 crear detailpurchase

### DIFF
--- a/src/AppForSEII2526.API/Data/SeedData.cs
+++ b/src/AppForSEII2526.API/Data/SeedData.cs
@@ -55,6 +55,26 @@ namespace AppForSEII2526.API.Data
                         string.Join(", ", result2.Errors.Select(e => e.Description)));
                 }
             }
+            var existingUser3 = await userManager.FindByEmailAsync("maria@uclm.es");
+            if (existingUser3 == null)
+            {
+                var user3 = new ApplicationUser
+                {
+                    UserName = "maria@uclm.es",
+                    Email = "maria@uclm.es",
+                    Name = "Maria",
+                    Surname = "Test",
+                    EmailConfirmed = true
+                };
+
+                var result3 = await userManager.CreateAsync(user3, "Aa123456789@");
+
+                if (!result3.Succeeded)
+                {
+                    throw new Exception("Error creando el usuario Maria: " +
+                        string.Join(", ", result3.Errors.Select(e => e.Description)));
+                }
+            }
         }
     }
 }

--- a/src/AppForSEII2526.Web/Components/Pages/Purchase/CreatePurchase.razor
+++ b/src/AppForSEII2526.Web/Components/Pages/Purchase/CreatePurchase.razor
@@ -129,6 +129,7 @@ else
     private bool IsSaving;
     private string? ErrorMessage;
     private Dictionary<string, string> ValidationErrors = new();
+    private const string DefaultCustomerUserName = "maria@uclm.es";
 
     private void GoBackToCart()
     {
@@ -169,6 +170,8 @@ else
 
         try
         {
+            PurchaseState.CustomerUserName ??= DefaultCustomerUserName;
+
             var purchaseForCreate = PurchaseState.ToPurchaseForCreateDTO();
 
             var createdPurchase = await ApiClient.CreatePurchaseAsync(purchaseForCreate);

--- a/src/AppForSEII2526.Web/Components/Pages/Purchase/DetailPurchase.razor
+++ b/src/AppForSEII2526.Web/Components/Pages/Purchase/DetailPurchase.razor
@@ -1,0 +1,144 @@
+﻿@page "/purchase/detailpurchase/{PurchaseId:int}"
+@using AppForSEII2526.Web.API
+@inject AppForSEII2526APIClient ApiClient
+@inject NavigationManager Navigation
+
+<h3>Comprobante de compra</h3>
+
+@if (IsLoading)
+{
+    <p>Cargando detalle de la compra...</p>
+}
+else if (!string.IsNullOrWhiteSpace(ErrorMessage))
+{
+    <div id="purchaseDetailError" class="alert alert-danger">
+        @ErrorMessage
+    </div>
+
+    <button id="backToPurchaseSelection"
+            class="btn btn-secondary"
+            @onclick="GoToPurchaseSelection">
+        Volver a comprar dispositivos
+    </button>
+}
+else if (PurchaseDetail is not null)
+{
+    <div id="purchaseDetail">
+        <h4>Datos del cliente</h4>
+
+        <p id="purchaseCustomerName">
+            <strong>Nombre:</strong> @PurchaseDetail.Name
+        </p>
+
+        <p id="purchaseCustomerSurname">
+            <strong>Apellidos:</strong> @PurchaseDetail.Surname
+        </p>
+
+        <p id="purchaseDeliveryAddress">
+            <strong>Dirección de entrega:</strong> @PurchaseDetail.DeliveryAddress
+        </p>
+
+        <p id="purchaseDate">
+            <strong>Fecha de compra:</strong> @PurchaseDetail.PurchaseDateUtc.ToLocalTime().ToString("dd/MM/yyyy HH:mm")
+        </p>
+
+        <h4>Resumen de la compra</h4>
+
+        <p id="purchaseTotalQuantity">
+            <strong>Cantidad total:</strong> @PurchaseDetail.TotalQuantity
+        </p>
+
+        <p id="purchaseTotalPrice">
+            <strong>Precio total:</strong> @PurchaseDetail.TotalPrice.ToString("0.00") €
+        </p>
+
+        <h4>Dispositivos comprados</h4>
+
+        @if (PurchaseDetail.PurchaseItems is null || !PurchaseDetail.PurchaseItems.Any())
+        {
+            <p id="noPurchaseItemsMessage">
+                No hay dispositivos asociados a esta compra.
+            </p>
+        }
+        else
+        {
+            <table id="PurchaseDetailItemsTable" class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>Marca</th>
+                        <th>Modelo</th>
+                        <th>Color</th>
+                        <th>Precio unitario</th>
+                        <th>Cantidad</th>
+                        <th>Subtotal</th>
+                        <th>Descripción</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in PurchaseDetail.PurchaseItems)
+                    {
+                        <tr id="@($"PurchaseDetailItem_{item.DeviceId}")">
+                            <td>@item.Brand</td>
+                            <td>@item.Model</td>
+                            <td>@item.Color</td>
+                            <td>@item.Price.ToString("0.00") €</td>
+                            <td>@item.Quantity</td>
+                            <td>@((item.Price * item.Quantity).ToString("0.00")) €</td>
+                            <td>@item.Description</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+
+        <button id="newPurchaseButton"
+                class="btn btn-primary"
+                @onclick="GoToPurchaseSelection">
+            Realizar otra compra
+        </button>
+    </div>
+}
+
+@code {
+    [Parameter]
+    public int PurchaseId { get; set; }
+
+    private PurchaseDetailDTO? PurchaseDetail;
+    private bool IsLoading;
+    private string? ErrorMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadPurchaseDetailAsync();
+    }
+
+    private async Task LoadPurchaseDetailAsync()
+    {
+        IsLoading = true;
+        ErrorMessage = null;
+
+        try
+        {
+            PurchaseDetail = await ApiClient.GetPurchaseAsync(PurchaseId);
+        }
+        catch (ApiException ex)
+        {
+            ErrorMessage = ex.StatusCode == 404
+                ? "No se ha encontrado la compra solicitada."
+                : ex.Response;
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = $"No se ha podido cargar el detalle de la compra: {ex.Message}";
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    private void GoToPurchaseSelection()
+    {
+        Navigation.NavigateTo("/purchase/selectdevicesforpurchase");
+    }
+}


### PR DESCRIPTION
Closes #154

## Sprint

Sprint 3

## Qué cambia

- Añadida la vista `DetailPurchase`.
- Añadida la página `/purchase/detailpurchase/{PurchaseId:int}`.
- Añadida carga del detalle de compra mediante `GetPurchaseAsync`.
- Mostrados los datos del cliente:
  - nombre
  - apellidos
  - dirección de entrega
- Mostrada la fecha de compra.
- Mostrada la cantidad total.
- Mostrado el precio total.
- Añadida tabla de dispositivos comprados.
- Para cada dispositivo se muestra:
  - marca
  - modelo
  - color
  - precio unitario
  - cantidad
  - subtotal
  - descripción
- Añadido mensaje de error si no se puede cargar la compra.
- Añadido botón para iniciar una nueva compra.
- Verificada la navegación desde `CreatePurchase` hasta `DetailPurchase` tras guardar una compra correctamente.

## Cómo se ha probado

- `dotnet build src\AppForSEII2526.API\AppForSEII2526.API.csproj`
- `dotnet build src\AppForSEII2526.Web\AppForSEII2526.Web.csproj`
- Prueba manual del flujo completo:
  - añadir dispositivo desde `/purchase/selectdevicesforpurchase`
  - continuar a `/purchase/createpurchase`
  - rellenar los datos de compra
  - guardar la compra
  - navegar automáticamente a `/purchase/detailpurchase/{id}`
- Comprobado que se muestran:
  - nombre
  - apellidos
  - dirección de entrega
  - fecha de compra
  - cantidad total
  - precio total
  - dispositivos comprados
  - marca, modelo, color, precio, cantidad, subtotal y descripción
- Comprobado el botón `Realizar otra compra`.

## Relación

- Implementa US4 – Ver comprobante de compra #14.
- Relacionado con US3 – Formalizar compra #13.
- Relacionado con la épica Como cliente quiero comprar un dispositivo electrónico para tenerlo en propiedad #10.