### PR TITLE
feat(web): añadir enlace Comprar dispositivo en NavMenu

### DIFF
--- a/src/AppForSEII2526.Web/Components/Layout/NavMenu.razor
+++ b/src/AppForSEII2526.Web/Components/Layout/NavMenu.razor
@@ -19,6 +19,12 @@
         </div>
 
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="purchase/selectdevicesforpurchase" Match="NavLinkMatch.Prefix">
+                <span id="createPurchaseNavbarButton" class="bi bi-cart-plus-fill-nav-menu" aria-hidden="true"></span> Comprar dispositivo
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="review/listdevicesforreview">
                 <span id="createReviewNavbarButton" class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Create review
             </NavLink>


### PR DESCRIPTION
Closes #155

## Sprint

Sprint 3

## Qué cambia

- Añadido enlace `Comprar dispositivo` en `NavMenu`.
- El enlace navega a `/purchase/selectdevicesforpurchase`.
- Se permite iniciar el flujo del CU1 Comprar dispositivo desde el menú principal.

## Cómo se ha probado

- `dotnet build src\AppForSEII2526.Web\AppForSEII2526.Web.csproj`
- Prueba manual de navegación desde el menú.
- Comprobado que el enlace abre la vista `SelectDevicesForPurchase`.

## Relación

- Implementa parcialmente #10.
- Relacionado con #11.