### PR TITLE
feat(web): restringir compra a usuarios autenticados

### DIFF
--- a/src/AppForSEII2526.Web/Components/Layout/NavMenu.razor
+++ b/src/AppForSEII2526.Web/Components/Layout/NavMenu.razor
@@ -18,11 +18,15 @@
             </NavLink>
         </div>
 
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="purchase/selectdevicesforpurchase" Match="NavLinkMatch.Prefix">
-                <span id="createPurchaseNavbarButton" class="bi bi-cart-plus-fill-nav-menu" aria-hidden="true"></span> Comprar dispositivo
-            </NavLink>
-        </div>
+        <AuthorizeView>
+            <Authorized>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="purchase/selectdevicesforpurchase" Match="NavLinkMatch.Prefix">
+                        <span id="createPurchaseNavbarButton" class="bi bi-cart-plus-fill-nav-menu" aria-hidden="true"></span> Comprar dispositivo
+                    </NavLink>
+                </div>
+            </Authorized>
+        </AuthorizeView>
 
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="review/listdevicesforreview">

--- a/src/AppForSEII2526.Web/Components/Pages/Purchase/CreatePurchase.razor
+++ b/src/AppForSEII2526.Web/Components/Pages/Purchase/CreatePurchase.razor
@@ -1,9 +1,12 @@
 ﻿@page "/purchase/createpurchase"
+@attribute [Authorize]
 @using AppForSEII2526.Web.API
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
 @inject AppForSEII2526APIClient ApiClient
 @inject PurchaseStateContainer PurchaseState
 @inject NavigationManager Navigation
-
+@inject AuthenticationStateProvider AuthenticationStateProvider
 
 <h3>Formalizar compra</h3>
 
@@ -129,7 +132,6 @@ else
     private bool IsSaving;
     private string? ErrorMessage;
     private Dictionary<string, string> ValidationErrors = new();
-    private const string DefaultCustomerUserName = "maria@uclm.es";
 
     private void GoBackToCart()
     {
@@ -170,7 +172,16 @@ else
 
         try
         {
-            PurchaseState.CustomerUserName ??= DefaultCustomerUserName;
+            var authenticationState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+            var userName = authenticationState.User.Identity?.Name;
+
+            if (string.IsNullOrWhiteSpace(userName))
+            {
+                ErrorMessage = "No se ha podido identificar al usuario autenticado.";
+                return;
+            }
+
+            PurchaseState.CustomerUserName = userName;
 
             var purchaseForCreate = PurchaseState.ToPurchaseForCreateDTO();
 

--- a/src/AppForSEII2526.Web/Components/Pages/Purchase/DetailPurchase.razor
+++ b/src/AppForSEII2526.Web/Components/Pages/Purchase/DetailPurchase.razor
@@ -1,5 +1,7 @@
 ﻿@page "/purchase/detailpurchase/{PurchaseId:int}"
+@attribute [Authorize]
 @using AppForSEII2526.Web.API
+@using Microsoft.AspNetCore.Authorization
 @inject AppForSEII2526APIClient ApiClient
 @inject NavigationManager Navigation
 

--- a/src/AppForSEII2526.Web/Components/Pages/Purchase/SelectDevicesForPurchase.razor
+++ b/src/AppForSEII2526.Web/Components/Pages/Purchase/SelectDevicesForPurchase.razor
@@ -1,6 +1,8 @@
 ﻿@page "/purchase/selectdevicesforpurchase"
+@attribute [Authorize]
 @implements IDisposable
 @using AppForSEII2526.Web.API
+@using Microsoft.AspNetCore.Authorization
 @inject AppForSEII2526APIClient ApiClient
 @inject PurchaseStateContainer PurchaseState
 @inject NavigationManager Navigation


### PR DESCRIPTION
Closes #156

## Sprint

Sprint 3

## Qué cambia

- Añadido `[Authorize]` a `SelectDevicesForPurchase`.
- Añadido `[Authorize]` a `CreatePurchase`.
- Añadido `[Authorize]` a `DetailPurchase`.
- Ocultado el enlace `Comprar dispositivo` en `NavMenu` para usuarios no autenticados.
- Actualizado `CreatePurchase` para obtener el usuario autenticado mediante `AuthenticationStateProvider`.
- Asignado `CustomerUserName` a partir del usuario autenticado antes de crear la compra.
- Añadido mensaje de error si no se puede identificar al usuario autenticado.
- Mantenido el identificador `createPurchaseNavbarButton` para futuras pruebas funcionales.

## Cómo se ha probado

- `dotnet build src\AppForSEII2526.Web\AppForSEII2526.Web.csproj`
- Comprobado que el enlace `Comprar dispositivo` aparece solo con sesión iniciada.
- Comprobado que las vistas de compra requieren usuario autenticado.
- Comprobado que un usuario loggeado puede realizar el flujo de compra.
- Comprobado que `CreatePurchase` usa el usuario autenticado para crear la compra.

## Nota

Actualmente se permite el acceso a cualquier usuario loggeado.  
La restricción estricta por rol `Cliente` queda pendiente hasta que los roles estén integrados de forma estable en el flujo Web.

## Relación

- Relacionado con la épica #10.
- Relacionado con  #13.
- Relacionado con #14.
- Relacionado con #15.