### PR TITLE
test(uit): añadir page objects para compra

### DIFF
--- a/test/AppForSEII2526.UIT/Shared/CU_Compras/CreatePurchasePageObject.cs
+++ b/test/AppForSEII2526.UIT/Shared/CU_Compras/CreatePurchasePageObject.cs
@@ -1,0 +1,91 @@
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using Xunit.Abstractions;
+
+namespace AppForSEII2526.UIT.Shared.CU_Compras;
+
+public class CreatePurchasePageObject : PageObject
+{
+    private readonly By _purchaseName = By.Id("purchaseName");
+    private readonly By _purchaseSurname = By.Id("purchaseSurname");
+    private readonly By _purchaseDeliveryAddress = By.Id("purchaseDeliveryAddress");
+    private readonly By _paymentMethodSelected = By.Id("paymentMethodSelected");
+    private readonly By _modifyPurchaseCart = By.Id("modifyPurchaseCart");
+    private readonly By _savePurchase = By.Id("savePurchase");
+    private readonly By _createPurchaseTotalQuantity = By.Id("createPurchaseTotalQuantity");
+    private readonly By _createPurchaseTotalPrice = By.Id("createPurchaseTotalPrice");
+    private readonly By _purchaseNameError = By.Id("purchaseNameError");
+    private readonly By _purchaseSurnameError = By.Id("purchaseSurnameError");
+    private readonly By _purchaseDeliveryAddressError = By.Id("purchaseDeliveryAddressError");
+    private readonly By _createPurchaseError = By.Id("createPurchaseError");
+
+    public CreatePurchasePageObject(IWebDriver driver, ITestOutputHelper output)
+        : base(driver, output)
+    {
+    }
+
+    public void FillCustomerData(string name, string surname, string deliveryAddress)
+    {
+        WaitForBeingVisible(_purchaseName);
+
+        _driver.FindElement(_purchaseName).Clear();
+        _driver.FindElement(_purchaseName).SendKeys(name);
+
+        _driver.FindElement(_purchaseSurname).Clear();
+        _driver.FindElement(_purchaseSurname).SendKeys(surname);
+
+        _driver.FindElement(_purchaseDeliveryAddress).Clear();
+        _driver.FindElement(_purchaseDeliveryAddress).SendKeys(deliveryAddress);
+    }
+
+    public void SelectPaymentMethod(string paymentMethodValue)
+    {
+        WaitForBeingVisible(_paymentMethodSelected);
+        var select = new SelectElement(_driver.FindElement(_paymentMethodSelected));
+        select.SelectByValue(paymentMethodValue);
+    }
+
+    public void SavePurchase()
+    {
+        WaitForBeingClickable(_savePurchase);
+        _driver.FindElement(_savePurchase).Click();
+    }
+
+    public void ModifyCart()
+    {
+        WaitForBeingClickable(_modifyPurchaseCart);
+        _driver.FindElement(_modifyPurchaseCart).Click();
+    }
+
+    public string GetTotalQuantity()
+    {
+        WaitForBeingVisible(_createPurchaseTotalQuantity);
+        return _driver.FindElement(_createPurchaseTotalQuantity).Text;
+    }
+
+    public string GetTotalPrice()
+    {
+        WaitForBeingVisible(_createPurchaseTotalPrice);
+        return _driver.FindElement(_createPurchaseTotalPrice).Text;
+    }
+
+    public bool HasNameError()
+    {
+        return _driver.FindElements(_purchaseNameError).Any();
+    }
+
+    public bool HasSurnameError()
+    {
+        return _driver.FindElements(_purchaseSurnameError).Any();
+    }
+
+    public bool HasDeliveryAddressError()
+    {
+        return _driver.FindElements(_purchaseDeliveryAddressError).Any();
+    }
+
+    public bool HasCreatePurchaseError()
+    {
+        return _driver.FindElements(_createPurchaseError).Any();
+    }
+}

--- a/test/AppForSEII2526.UIT/Shared/CU_Compras/DetailPurchasePageObject.cs
+++ b/test/AppForSEII2526.UIT/Shared/CU_Compras/DetailPurchasePageObject.cs
@@ -1,0 +1,68 @@
+﻿using OpenQA.Selenium;
+using Xunit.Abstractions;
+
+namespace AppForSEII2526.UIT.Shared.CU_Compras;
+
+public class DetailPurchasePageObject : PageObject
+{
+    private readonly By _purchaseDetail = By.Id("purchaseDetail");
+    private readonly By _purchaseCustomerName = By.Id("purchaseCustomerName");
+    private readonly By _purchaseCustomerSurname = By.Id("purchaseCustomerSurname");
+    private readonly By _purchaseDeliveryAddress = By.Id("purchaseDeliveryAddress");
+    private readonly By _purchaseDate = By.Id("purchaseDate");
+    private readonly By _purchaseTotalQuantity = By.Id("purchaseTotalQuantity");
+    private readonly By _purchaseTotalPrice = By.Id("purchaseTotalPrice");
+    private readonly By _purchaseDetailItemsTable = By.Id("PurchaseDetailItemsTable");
+    private readonly By _newPurchaseButton = By.Id("newPurchaseButton");
+
+    public DetailPurchasePageObject(IWebDriver driver, ITestOutputHelper output)
+        : base(driver, output)
+    {
+    }
+
+    public bool IsLoaded()
+    {
+        return _driver.FindElements(_purchaseDetail).Any();
+    }
+
+    public string GetCustomerName()
+    {
+        WaitForBeingVisible(_purchaseCustomerName);
+        return _driver.FindElement(_purchaseCustomerName).Text;
+    }
+
+    public string GetCustomerSurname()
+    {
+        WaitForBeingVisible(_purchaseCustomerSurname);
+        return _driver.FindElement(_purchaseCustomerSurname).Text;
+    }
+
+    public string GetDeliveryAddress()
+    {
+        WaitForBeingVisible(_purchaseDeliveryAddress);
+        return _driver.FindElement(_purchaseDeliveryAddress).Text;
+    }
+
+    public string GetTotalQuantity()
+    {
+        WaitForBeingVisible(_purchaseTotalQuantity);
+        return _driver.FindElement(_purchaseTotalQuantity).Text;
+    }
+
+    public string GetTotalPrice()
+    {
+        WaitForBeingVisible(_purchaseTotalPrice);
+        return _driver.FindElement(_purchaseTotalPrice).Text;
+    }
+
+    public bool IsItemsTableVisible()
+    {
+        return _driver.FindElements(_purchaseDetailItemsTable).Any();
+    }
+
+    public void StartNewPurchase()
+    {
+        WaitForBeingClickable(_newPurchaseButton);
+        _driver.FindElement(_newPurchaseButton).Click();
+    }
+}

--- a/test/AppForSEII2526.UIT/Shared/CU_Compras/SelectDevicesForPurchasePageObject.cs
+++ b/test/AppForSEII2526.UIT/Shared/CU_Compras/SelectDevicesForPurchasePageObject.cs
@@ -1,0 +1,112 @@
+﻿using OpenQA.Selenium;
+using Xunit.Abstractions;
+
+namespace AppForSEII2526.UIT.Shared.CU_Compras;
+
+public class SelectDevicesForPurchasePageObject : PageObject
+{
+    private readonly By _searchDevices = By.Id("searchDevices");
+    private readonly By _selectColor = By.Id("selectColor");
+    private readonly By _searchDevicesButton = By.Id("searchDevicesButton");
+    private readonly By _clearDeviceFiltersButton = By.Id("clearDeviceFiltersButton");
+    private readonly By _tableOfDevices = By.Id("TableOfDevices");
+    private readonly By _purchaseDevicesButton = By.Id("purchaseDevicesButton");
+    private readonly By _emptyCartMessage = By.Id("emptyCartMessage");
+    private readonly By _cartTotalQuantity = By.Id("cartTotalQuantity");
+    private readonly By _cartTotalPrice = By.Id("cartTotalPrice");
+
+    public SelectDevicesForPurchasePageObject(IWebDriver driver, ITestOutputHelper output)
+        : base(driver, output)
+    {
+    }
+
+    public void SearchByName(string name)
+    {
+        WaitForBeingVisible(_searchDevices);
+        _driver.FindElement(_searchDevices).Clear();
+        _driver.FindElement(_searchDevices).SendKeys(name);
+        _driver.FindElement(_searchDevicesButton).Click();
+    }
+
+    public void SearchByColor(string color)
+    {
+        WaitForBeingVisible(_selectColor);
+        _driver.FindElement(_selectColor).Clear();
+        _driver.FindElement(_selectColor).SendKeys(color);
+        _driver.FindElement(_searchDevicesButton).Click();
+    }
+
+    public void SearchByNameAndColor(string name, string color)
+    {
+        WaitForBeingVisible(_searchDevices);
+        _driver.FindElement(_searchDevices).Clear();
+        _driver.FindElement(_searchDevices).SendKeys(name);
+
+        _driver.FindElement(_selectColor).Clear();
+        _driver.FindElement(_selectColor).SendKeys(color);
+
+        _driver.FindElement(_searchDevicesButton).Click();
+    }
+
+    public void ClearFilters()
+    {
+        WaitForBeingClickable(_clearDeviceFiltersButton);
+        _driver.FindElement(_clearDeviceFiltersButton).Click();
+    }
+
+    public void AddDevice(string deviceName)
+    {
+        var addDeviceButton = By.Id($"deviceToBuy_{deviceName}");
+        WaitForBeingClickable(addDeviceButton);
+        _driver.FindElement(addDeviceButton).Click();
+    }
+
+    public void RemoveDevice(int deviceId)
+    {
+        var removeDeviceButton = By.Id($"removeDevice_{deviceId}");
+        WaitForBeingClickable(removeDeviceButton);
+        _driver.FindElement(removeDeviceButton).Click();
+    }
+
+    public void IncreaseQuantity(int deviceId)
+    {
+        var increaseQuantityButton = By.Id($"increaseQuantity_{deviceId}");
+        WaitForBeingClickable(increaseQuantityButton);
+        _driver.FindElement(increaseQuantityButton).Click();
+    }
+
+    public void DecreaseQuantity(int deviceId)
+    {
+        var decreaseQuantityButton = By.Id($"decreaseQuantity_{deviceId}");
+        WaitForBeingClickable(decreaseQuantityButton);
+        _driver.FindElement(decreaseQuantityButton).Click();
+    }
+
+    public void ContinuePurchase()
+    {
+        WaitForBeingClickable(_purchaseDevicesButton);
+        _driver.FindElement(_purchaseDevicesButton).Click();
+    }
+
+    public bool IsDevicesTableVisible()
+    {
+        return _driver.FindElements(_tableOfDevices).Any();
+    }
+
+    public bool IsEmptyCartMessageVisible()
+    {
+        return _driver.FindElements(_emptyCartMessage).Any();
+    }
+
+    public string GetCartTotalQuantity()
+    {
+        WaitForBeingVisible(_cartTotalQuantity);
+        return _driver.FindElement(_cartTotalQuantity).Text;
+    }
+
+    public string GetCartTotalPrice()
+    {
+        WaitForBeingVisible(_cartTotalPrice);
+        return _driver.FindElement(_cartTotalPrice).Text;
+    }
+}


### PR DESCRIPTION
Closes #157

## Sprint

Sprint 3

## Qué cambia

- Añadido `SelectDevicesForPurchasePageObject`.
- Añadido `CreatePurchasePageObject`.
- Añadido `DetailPurchasePageObject`.
- Añadidos métodos para automatizar filtros por nombre y color.
- Añadidos métodos para limpiar filtros.
- Añadidos métodos para añadir dispositivos al carrito.
- Añadidos métodos para eliminar dispositivos del carrito.
- Añadidos métodos para aumentar y disminuir cantidades.
- Añadidos métodos para continuar con la compra.
- Añadidos métodos para rellenar los datos de formalización de compra.
- Añadidos métodos para seleccionar método de pago.
- Añadidos métodos para guardar la compra.
- Añadidos métodos para comprobar errores de validación.
- Añadidos métodos para comprobar el detalle final de compra.

## Cómo se ha probado

- `dotnet build test\AppForSEII2526.UIT\AppForSEII2526.UIT.csproj`

## Relación

- Prepara la automatización funcional del CU1 Comprar dispositivo.
- Relacionado con #11.
- Relacionado con #12.
- Relacionado con #13.
- Relacionado con #14.
- Relacionado con #15.
- Relacionado con la épica #10.