### PR TITLE
PR-Gestión del carrito del CU Contratar reparación #177

### DIFF
--- a/src/AppForSEII2526.Web/Components/Pages/Repair/SelectRepairsForReceipt.razor
+++ b/src/AppForSEII2526.Web/Components/Pages/Repair/SelectRepairsForReceipt.razor
@@ -1,10 +1,13 @@
 ﻿@page "/repair/selectrepairsforreceipt"
 @attribute [Authorize]
+@implements IDisposable
 
 @using AppForSEII2526.Web.API
 @using Microsoft.AspNetCore.Authorization
 
 @inject AppForSEII2526APIClient ApiClient
+@inject RepairStateContainer RepairState
+@inject NavigationManager Navigation
 @inject ILogger<SelectRepairsForReceipt> Logger
 
 <h3>Contratar reparación</h3>
@@ -37,7 +40,7 @@
                            placeholder="Lujo, media o básica" />
             </div>
 
-            <div class="col-md-2 d-flex align-items-end gap-2">
+            <div class="col-md-2 d-flex align-items-end">
                 <button class="btn btn-primary w-100"
                         type="button"
                         @onclick="SearchRepairs">
@@ -58,46 +61,108 @@
 
 @if (IsLoading)
 {
-    <div class="alert alert-info">
-        Cargando reparaciones...
-    </div>
+        <div class="alert alert-info">
+            Cargando reparaciones...
+        </div>
 }
 else if (!string.IsNullOrWhiteSpace(ErrorMessage))
 {
-    <div class="alert alert-danger">
+        <div class="alert alert-danger">
         @ErrorMessage
-    </div>
+        </div>
 }
 else if (Repairs is null || !Repairs.Any())
 {
-    <div class="alert alert-warning">
-        No hay reparaciones disponibles con los filtros seleccionados.
-    </div>
+        <div class="alert alert-warning">
+            No hay reparaciones disponibles con los filtros seleccionados.
+        </div>
 }
 else
 {
-    <table class="table table-striped table-hover align-middle">
-        <thead>
-            <tr>
-                <th>Nombre</th>
-                <th>Escala</th>
-                <th>Descripción</th>
-                <th class="text-end">Coste</th>
-            </tr>
-        </thead>
-        <tbody>
+        <table class="table table-striped table-hover align-middle">
+            <thead>
+                <tr>
+                    <th>Nombre</th>
+                    <th>Escala</th>
+                    <th>Descripción</th>
+                    <th class="text-end">Coste</th>
+                    <th class="text-center">Acción</th>
+                </tr>
+            </thead>
+            <tbody>
             @foreach (var repair in Repairs)
             {
-                <tr>
-                    <td>@repair.Name</td>
-                    <td>@repair.Scale</td>
-                    <td>@repair.Description</td>
-                    <td class="text-end">@repair.Cost.ToString("0.00") €</td>
-                </tr>
+                        <tr>
+                            <td>@repair.Name</td>
+                            <td>@repair.Scale</td>
+                            <td>@repair.Description</td>
+                            <td class="text-end">@repair.Cost.ToString("0.00") €</td>
+                            <td class="text-center">
+                                <button class="btn btn-sm btn-success"
+                                        type="button"
+                                        disabled="@RepairState.ContainsRepair(repair.Id)"
+                                        @onclick="() => AddRepairToCart(repair)">
+                            @(RepairState.ContainsRepair(repair.Id) ? "Añadida" : "Añadir")
+                                </button>
+                            </td>
+                        </tr>
             }
-        </tbody>
-    </table>
+            </tbody>
+        </table>
 }
+
+<hr />
+
+<h4>Carrito de reparación</h4>
+
+@if (!RepairState.HasItems)
+{
+        <div class="alert alert-info">
+            Añade al menos una reparación al carrito para continuar con la contratación.
+        </div>
+}
+else
+{
+        <table class="table table-bordered align-middle">
+            <thead>
+                <tr>
+                    <th>Nombre</th>
+                    <th>Escala</th>
+                    <th class="text-end">Coste</th>
+                    <th class="text-center">Eliminar</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var repair in RepairState.SelectedRepairs)
+            {
+                        <tr>
+                            <td>@repair.Name</td>
+                            <td>@repair.Scale</td>
+                            <td class="text-end">@repair.Cost.ToString("0.00") €</td>
+                            <td class="text-center">
+                                <button class="btn btn-sm btn-danger"
+                                        type="button"
+                                        @onclick="() => RemoveRepairFromCart(repair.Id)">
+                                    Eliminar
+                                </button>
+                            </td>
+                        </tr>
+            }
+            </tbody>
+        </table>
+
+        <div class="text-end mb-3">
+            <strong>Total: @RepairState.TotalPrice.ToString("0.00") €</strong>
+        </div>
+}
+
+<button class="btn btn-primary"
+        type="button"
+        disabled="@(!RepairState.HasItems)"
+        title="@GetContinueButtonTitle()"
+        @onclick="ContinueReceipt">
+    Continuar
+</button>
 
 @code {
     private string? RepairNameFilter { get; set; }
@@ -110,6 +175,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        RepairState.OnChange += StateHasChanged;
         await SearchRepairs();
     }
 
@@ -142,11 +208,43 @@ else
         }
     }
 
+    private void AddRepairToCart(RepairForReceiptDTO repair)
+    {
+        RepairState.AddRepair(repair);
+    }
+
+    private void RemoveRepairFromCart(int repairId)
+    {
+        RepairState.RemoveRepair(repairId);
+    }
+
+    private void ContinueReceipt()
+    {
+        if (!RepairState.HasItems)
+        {
+            return;
+        }
+
+        Navigation.NavigateTo("/repair/createreceipt");
+    }
+
+    private string GetContinueButtonTitle()
+    {
+        return RepairState.HasItems
+            ? "Continuar con la contratación de reparación"
+            : "Añade al menos una reparación al carrito para continuar";
+    }
+
     private async Task ClearFilters()
     {
         RepairNameFilter = null;
         ScaleFilter = null;
 
         await SearchRepairs();
+    }
+
+    public void Dispose()
+    {
+        RepairState.OnChange -= StateHasChanged;
     }
 }

--- a/src/AppForSEII2526.Web/Program.cs
+++ b/src/AppForSEII2526.Web/Program.cs
@@ -42,6 +42,8 @@ builder.Services.AddScoped<ReviewStateContainer>();
 builder.Services.AddScoped<RentalStateContainer>();
 //incorporacion de PurchaseStateContainer
 builder.Services.AddScoped<PurchaseStateContainer>();
+//incorporacion de RepairStateContainer
+builder.Services.AddScoped<RepairStateContainer>();
 //incorporacion del clientAPI
 builder.Services.AddHttpClient(); // Registra el HttpClientFactory
 

--- a/src/AppForSEII2526.Web/RepairStateContainer.cs
+++ b/src/AppForSEII2526.Web/RepairStateContainer.cs
@@ -1,0 +1,109 @@
+﻿using AppForSEII2526.Web.API;
+
+namespace AppForSEII2526.Web
+{
+    public class RepairStateContainer
+    {
+        public IList<ReceiptItemForCreateDTO> ReceiptItems { get; private set; } =
+            new List<ReceiptItemForCreateDTO>();
+
+        public IList<RepairForReceiptDTO> SelectedRepairs { get; private set; } =
+            new List<RepairForReceiptDTO>();
+
+        public string? CustomerUserName { get; set; }
+
+        public string? CustomerNameSurname { get; set; }
+
+        public string? DeliveryAddress { get; set; }
+
+        public PaymentMethodTypes PaymentMethod { get; set; } = PaymentMethodTypes.CreditCard;
+
+        public event Action? OnChange;
+
+        public bool HasItems => ReceiptItems.Any();
+
+        public double TotalPrice => SelectedRepairs.Sum(repair => repair.Cost);
+
+        public bool ContainsRepair(int repairId)
+        {
+            return ReceiptItems.Any(item => item.RepairId == repairId);
+        }
+
+        public void AddRepair(RepairForReceiptDTO repair)
+        {
+            if (ContainsRepair(repair.Id))
+            {
+                return;
+            }
+
+            SelectedRepairs.Add(repair);
+
+            ReceiptItems.Add(new ReceiptItemForCreateDTO
+            {
+                RepairId = repair.Id,
+                Model = string.Empty
+            });
+
+            NotifyStateChanged();
+        }
+
+        public void RemoveRepair(int repairId)
+        {
+            var receiptItem = ReceiptItems.FirstOrDefault(item => item.RepairId == repairId);
+
+            if (receiptItem is not null)
+            {
+                ReceiptItems.Remove(receiptItem);
+            }
+
+            var selectedRepair = SelectedRepairs.FirstOrDefault(repair => repair.Id == repairId);
+
+            if (selectedRepair is not null)
+            {
+                SelectedRepairs.Remove(selectedRepair);
+            }
+
+            NotifyStateChanged();
+        }
+
+        public void UpdateModel(int repairId, string? model)
+        {
+            var receiptItem = ReceiptItems.FirstOrDefault(item => item.RepairId == repairId);
+
+            if (receiptItem is not null)
+            {
+                receiptItem.Model = model ?? string.Empty;
+                NotifyStateChanged();
+            }
+        }
+
+        public ReceiptForCreateDTO ToReceiptForCreateDTO()
+        {
+            return new ReceiptForCreateDTO
+            {
+                CustomerUserName = CustomerUserName ?? string.Empty,
+                CustomerNameSurname = CustomerNameSurname ?? string.Empty,
+                DeliveryAddress = DeliveryAddress ?? string.Empty,
+                PaymentMethod = PaymentMethod,
+                ReceiptItems = ReceiptItems.ToList()
+            };
+        }
+
+        public void Clear()
+        {
+            ReceiptItems.Clear();
+            SelectedRepairs.Clear();
+            CustomerUserName = null;
+            CustomerNameSurname = null;
+            DeliveryAddress = null;
+            PaymentMethod = PaymentMethodTypes.CreditCard;
+
+            NotifyStateChanged();
+        }
+
+        private void NotifyStateChanged()
+        {
+            OnChange?.Invoke();
+        }
+    }
+}


### PR DESCRIPTION
Implementada la gestión del carrito del caso de uso Contratar reparación.

Incluye:
- Creación de RepairStateContainer.
- Registro del contenedor de estado en Program.cs.
- Selección de reparaciones desde SelectRepairsForReceipt.
- Eliminación de reparaciones del carrito.
- Recalculo automático del precio total.
- Botón Continuar deshabilitado cuando el carrito está vacío.
- Conservación del estado de las reparaciones seleccionadas entre vistas.

Closes #177