### PR TITLE
PR-Implementa creación y detalle del recibo de reparación #178

### DIFF
--- a/src/AppForSEII2526.Web/Components/Pages/Repair/CreateReceipt.razor
+++ b/src/AppForSEII2526.Web/Components/Pages/Repair/CreateReceipt.razor
@@ -1,0 +1,254 @@
+﻿@page "/repair/createreceipt"
+@attribute [Authorize]
+
+@using AppForSEII2526.Web.API
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
+
+@inject RepairStateContainer RepairState
+@inject AppForSEII2526APIClient ApiClient
+@inject NavigationManager Navigation
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject ILogger<CreateReceipt> Logger
+
+<h3>Confirmar reparación</h3>
+
+<p>
+    Revisa las reparaciones seleccionadas e introduce los datos necesarios para generar el recibo.
+</p>
+
+@if (!RepairState.HasItems)
+{
+    <div class="alert alert-warning">
+        No hay reparaciones seleccionadas. Vuelve a la pantalla anterior para añadir reparaciones al carrito.
+    </div>
+
+    <button class="btn btn-primary" type="button" @onclick="GoBackToSelection">
+        Volver a seleccionar reparaciones
+    </button>
+}
+else
+{
+    @if (ValidationErrors.Any())
+    {
+        <div class="alert alert-danger">
+            <strong>Revisa los siguientes errores:</strong>
+            <ul class="mb-0">
+                @foreach (var error in ValidationErrors)
+                {
+                    <li>@error</li>
+                }
+            </ul>
+        </div>
+    }
+
+    @if (!string.IsNullOrWhiteSpace(ErrorMessage))
+    {
+        <div class="alert alert-danger">
+            @ErrorMessage
+        </div>
+    }
+
+    <div class="card mb-4">
+        <div class="card-header">
+            <strong>Reparaciones seleccionadas</strong>
+        </div>
+
+        <div class="card-body">
+            <table class="table table-bordered align-middle">
+                <thead>
+                    <tr>
+                        <th>Reparación</th>
+                        <th>Escala</th>
+                        <th class="text-end">Coste</th>
+                        <th>Modelo del dispositivo</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var repair in RepairState.SelectedRepairs)
+                    {
+                        <tr>
+                            <td>@repair.Name</td>
+                            <td>@repair.Scale</td>
+                            <td class="text-end">@repair.Cost.ToString("0.00") €</td>
+                            <td>
+                                <InputText class="form-control"
+                                           placeholder="Ejemplo: iPhone 13, Samsung S22..."
+                                           @bind-Value="GetReceiptItem(repair.Id).Model" />
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+
+            <div class="text-end">
+                <strong>Total: @RepairState.TotalPrice.ToString("0.00") €</strong>
+            </div>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header">
+            <strong>Datos del cliente</strong>
+        </div>
+
+        <div class="card-body">
+            <div class="mb-3">
+                <label class="form-label" for="customerNameSurname">Nombre y apellidos</label>
+                <InputText id="customerNameSurname"
+                           class="form-control"
+                           @bind-Value="RepairState.CustomerNameSurname"
+                           placeholder="Introduce tu nombre y apellidos" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="deliveryAddress">Dirección de entrega</label>
+                <InputText id="deliveryAddress"
+                           class="form-control"
+                           @bind-Value="RepairState.DeliveryAddress"
+                           placeholder="Introduce la dirección de entrega" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" for="paymentMethod">Método de pago</label>
+                <InputSelect id="paymentMethod"
+                             class="form-select"
+                             @bind-Value="RepairState.PaymentMethod">
+                    <option value="@PaymentMethodTypes.CreditCard">Tarjeta de crédito</option>
+                    <option value="@PaymentMethodTypes.PayPal">PayPal</option>
+                    <option value="@PaymentMethodTypes.Cash">Efectivo</option>
+                </InputSelect>
+            </div>
+        </div>
+    </div>
+
+    <div class="d-flex gap-2">
+        <button class="btn btn-outline-secondary"
+                type="button"
+                @onclick="GoBackToSelection">
+            Modificar reparaciones
+        </button>
+
+        <button class="btn btn-success"
+                type="button"
+                disabled="@IsSaving"
+                @onclick="SaveReceipt">
+            @(IsSaving ? "Guardando..." : "Guardar recibo")
+        </button>
+    </div>
+}
+
+@code {
+    private bool IsSaving { get; set; }
+    private string? ErrorMessage { get; set; }
+    private List<string> ValidationErrors { get; set; } = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await SetCurrentUserName();
+    }
+
+    private async Task SetCurrentUserName()
+    {
+        var authenticationState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var userName = authenticationState.User.Identity?.Name;
+
+        if (!string.IsNullOrWhiteSpace(userName))
+        {
+            RepairState.CustomerUserName = userName;
+        }
+    }
+
+    private ReceiptItemForCreateDTO GetReceiptItem(int repairId)
+    {
+        var item = RepairState.ReceiptItems.FirstOrDefault(receiptItem => receiptItem.RepairId == repairId);
+
+        if (item is null)
+        {
+            item = new ReceiptItemForCreateDTO
+                {
+                    RepairId = repairId,
+                    Model = string.Empty
+                };
+
+            RepairState.ReceiptItems.Add(item);
+        }
+
+        return item;
+    }
+
+    private async Task SaveReceipt()
+    {
+        ValidationErrors.Clear();
+        ErrorMessage = null;
+
+        await SetCurrentUserName();
+
+        ValidateReceipt();
+
+        if (ValidationErrors.Any())
+        {
+            return;
+        }
+
+        IsSaving = true;
+
+        try
+        {
+            var receiptForCreate = RepairState.ToReceiptForCreateDTO();
+
+            var createdReceipt = await ApiClient.CreateReceiptAsync(receiptForCreate);
+
+            RepairState.Clear();
+
+            Navigation.NavigateTo($"/repair/detailreceipt/{createdReceipt.Id}");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error creating repair receipt");
+            ErrorMessage = $"No se ha podido crear el recibo: {ex.Message}";
+        }
+        finally
+        {
+            IsSaving = false;
+        }
+    }
+
+    private void ValidateReceipt()
+    {
+        if (!RepairState.HasItems)
+        {
+            ValidationErrors.Add("Debe seleccionar al menos una reparación.");
+        }
+
+        if (string.IsNullOrWhiteSpace(RepairState.CustomerUserName))
+        {
+            ValidationErrors.Add("El usuario debe estar autenticado para contratar una reparación.");
+        }
+
+        if (string.IsNullOrWhiteSpace(RepairState.CustomerNameSurname))
+        {
+            ValidationErrors.Add("El nombre y apellidos son obligatorios.");
+        }
+
+        if (string.IsNullOrWhiteSpace(RepairState.DeliveryAddress))
+        {
+            ValidationErrors.Add("La dirección de entrega es obligatoria.");
+        }
+
+        foreach (var item in RepairState.ReceiptItems)
+        {
+            var repair = RepairState.SelectedRepairs.FirstOrDefault(selectedRepair => selectedRepair.Id == item.RepairId);
+
+            if (string.IsNullOrWhiteSpace(item.Model))
+            {
+                ValidationErrors.Add($"Debe introducir el modelo del dispositivo para la reparación: {repair?.Name ?? item.RepairId.ToString()}.");
+            }
+        }
+    }
+
+    private void GoBackToSelection()
+    {
+        Navigation.NavigateTo("/repair/selectrepairsforreceipt");
+    }
+}

--- a/src/AppForSEII2526.Web/Components/Pages/Repair/DetailReceipt.razor
+++ b/src/AppForSEII2526.Web/Components/Pages/Repair/DetailReceipt.razor
@@ -1,0 +1,149 @@
+﻿@page "/repair/detailreceipt/{ReceiptId:int}"
+@attribute [Authorize]
+
+@using AppForSEII2526.Web.API
+@using Microsoft.AspNetCore.Authorization
+
+@inject AppForSEII2526APIClient ApiClient
+@inject NavigationManager Navigation
+@inject ILogger<DetailReceipt> Logger
+
+<h3>Detalle del recibo de reparación</h3>
+
+@if (IsLoading)
+{
+    <div class="alert alert-info">
+        Cargando recibo...
+    </div>
+}
+else if (!string.IsNullOrWhiteSpace(ErrorMessage))
+{
+    <div class="alert alert-danger">
+        @ErrorMessage
+    </div>
+
+    <button class="btn btn-primary" type="button" @onclick="GoToSelection">
+        Volver a contratar reparación
+    </button>
+}
+else if (Receipt is null)
+{
+    <div class="alert alert-warning">
+        No se ha encontrado el recibo solicitado.
+    </div>
+
+    <button class="btn btn-primary" type="button" @onclick="GoToSelection">
+        Volver a contratar reparación
+    </button>
+}
+else
+{
+    <div class="card mb-4">
+        <div class="card-header">
+            <strong>Datos del recibo</strong>
+        </div>
+
+        <div class="card-body">
+            <p><strong>Cliente:</strong> @Receipt.CustomerNameSurname</p>
+            <p><strong>Dirección:</strong> @Receipt.DeliveryAddress</p>
+            <p><strong>Fecha de operación:</strong> @Receipt.ReceiptDate.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</p>
+            <p><strong>Método de pago:</strong> @GetPaymentMethodText(Receipt.PaymentMethod)</p>
+            <p><strong>Precio total:</strong> @Receipt.TotalPrice.ToString("0.00") €</p>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header">
+            <strong>Reparaciones contratadas</strong>
+        </div>
+
+        <div class="card-body">
+            @if (Receipt.ReceiptItems is null || !Receipt.ReceiptItems.Any())
+            {
+                <div class="alert alert-warning">
+                    El recibo no contiene reparaciones asociadas.
+                </div>
+            }
+            else
+            {
+                <table class="table table-striped table-hover align-middle">
+                    <thead>
+                        <tr>
+                            <th>Reparación</th>
+                            <th>Escala</th>
+                            <th>Modelo del dispositivo</th>
+                            <th>Descripción</th>
+                            <th class="text-end">Coste</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Receipt.ReceiptItems)
+                        {
+                            <tr>
+                                <td>@item.RepairName</td>
+                                <td>@item.Scale</td>
+                                <td>@item.Model</td>
+                                <td>@item.RepairDescription</td>
+                                <td class="text-end">@item.RepairCost.ToString("0.00") €</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            }
+        </div>
+    </div>
+
+    <button class="btn btn-primary" type="button" @onclick="GoToSelection">
+        Contratar otra reparación
+    </button>
+}
+
+@code {
+    [Parameter]
+    public int ReceiptId { get; set; }
+
+    private ReceiptDetailDTO? Receipt { get; set; }
+    private bool IsLoading { get; set; }
+    private string? ErrorMessage { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadReceipt();
+    }
+
+    private async Task LoadReceipt()
+    {
+        IsLoading = true;
+        ErrorMessage = null;
+
+        try
+        {
+            Receipt = await ApiClient.GetReceiptAsync(ReceiptId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading repair receipt with id {ReceiptId}", ReceiptId);
+            ErrorMessage = $"No se ha podido cargar el recibo: {ex.Message}";
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    private static string GetPaymentMethodText(PaymentMethodTypes paymentMethod)
+    {
+        return paymentMethod switch
+        {
+            PaymentMethodTypes.CreditCard => "Tarjeta de crédito",
+            PaymentMethodTypes.PayPal => "PayPal",
+            PaymentMethodTypes.Cash => "Efectivo",
+            _ => paymentMethod.ToString()
+        };
+    }
+
+    private void GoToSelection()
+    {
+        Navigation.NavigateTo("/repair/selectrepairsforreceipt");
+    }
+}


### PR DESCRIPTION
Implementado el flujo de creación y detalle del recibo de reparación.

Incluye:
- Vista CreateReceipt.
- Formulario con nombre y apellidos, dirección y método de pago.
- Campo de modelo del dispositivo para cada reparación seleccionada.
- Validaciones básicas del formulario.
- Llamada a la API para crear el recibo.
- Vista DetailReceipt.
- Visualización del recibo creado con cliente, dirección, fecha, precio total y reparaciones contratadas.

Closes #178