### PR TITLE
test(uit): añadir pruebas funcionales de compra de dispositivo

### DIFF
--- a/src/AppForSEII2526.API/Data/SeedData.cs
+++ b/src/AppForSEII2526.API/Data/SeedData.cs
@@ -77,6 +77,26 @@ namespace AppForSEII2526.API.Data
                 throw new Exception($"Error creando el usuario {email}: " +
                     string.Join(", ", result.Errors.Select(e => e.Description)));
             }
+            var existingUser3 = await userManager.FindByEmailAsync("maria@uclm.es");
+            if (existingUser3 == null)
+            {
+                var user3 = new ApplicationUser
+                {
+                    UserName = "maria@uclm.es",
+                    Email = "maria@uclm.es",
+                    Name = "Maria",
+                    Surname = "Test",
+                    EmailConfirmed = true
+                };
+
+                var result3 = await userManager.CreateAsync(user3, "Aa123456789@");
+
+                if (!result3.Succeeded)
+                {
+                    throw new Exception("Error creando el usuario Maria: " +
+                        string.Join(", ", result3.Errors.Select(e => e.Description)));
+                }
+            }
         }
 
         private static void SeedRepairs(ApplicationDbContext context)

--- a/test/AppForSEII2526.UIT/Shared/CU_Compras/CreatePurchasePageObject.cs
+++ b/test/AppForSEII2526.UIT/Shared/CU_Compras/CreatePurchasePageObject.cs
@@ -26,7 +26,7 @@ public class CreatePurchasePageObject : PageObject
 
     public void FillCustomerData(string name, string surname, string deliveryAddress)
     {
-        WaitForBeingVisible(_purchaseName);
+        WaitForCreatePurchasePage();
 
         _driver.FindElement(_purchaseName).Clear();
         _driver.FindElement(_purchaseName).SendKeys(name);
@@ -49,12 +49,6 @@ public class CreatePurchasePageObject : PageObject
     {
         WaitForBeingClickable(_savePurchase);
         _driver.FindElement(_savePurchase).Click();
-    }
-
-    public void ModifyCart()
-    {
-        WaitForBeingClickable(_modifyPurchaseCart);
-        _driver.FindElement(_modifyPurchaseCart).Click();
     }
 
     public string GetTotalQuantity()
@@ -87,5 +81,31 @@ public class CreatePurchasePageObject : PageObject
     public bool HasCreatePurchaseError()
     {
         return _driver.FindElements(_createPurchaseError).Any();
+    }
+
+    public void WaitForCreatePurchasePage()
+    {
+        WaitForBeingVisible(_purchaseName);
+        WaitForBeingVisible(_purchaseSurname);
+        WaitForBeingVisible(_purchaseDeliveryAddress);
+        WaitForBeingVisible(_paymentMethodSelected);
+    }
+
+    public void SavePurchaseAndWaitForDetail()
+    {
+        WaitForBeingClickable(_savePurchase);
+        _driver.FindElement(_savePurchase).Click();
+
+        var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(15));
+        wait.Until(d => d.Url.ToLower().Contains("detailpurchase"));
+    }
+
+    public void ModifyCartAndWaitForSelection()
+    {
+        WaitForBeingClickable(_modifyPurchaseCart);
+        _driver.FindElement(_modifyPurchaseCart).Click();
+
+        var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(15));
+        wait.Until(d => d.FindElements(By.Id("TableOfDevices")).Any());
     }
 }

--- a/test/AppForSEII2526.UIT/Shared/CU_Compras/SelectDevicesForPurchasePageObject.cs
+++ b/test/AppForSEII2526.UIT/Shared/CU_Compras/SelectDevicesForPurchasePageObject.cs
@@ -8,12 +8,8 @@ public class SelectDevicesForPurchasePageObject : PageObject
     private readonly By _searchDevices = By.Id("searchDevices");
     private readonly By _selectColor = By.Id("selectColor");
     private readonly By _searchDevicesButton = By.Id("searchDevicesButton");
-    private readonly By _clearDeviceFiltersButton = By.Id("clearDeviceFiltersButton");
-    private readonly By _tableOfDevices = By.Id("TableOfDevices");
     private readonly By _purchaseDevicesButton = By.Id("purchaseDevicesButton");
     private readonly By _emptyCartMessage = By.Id("emptyCartMessage");
-    private readonly By _cartTotalQuantity = By.Id("cartTotalQuantity");
-    private readonly By _cartTotalPrice = By.Id("cartTotalPrice");
 
     public SelectDevicesForPurchasePageObject(IWebDriver driver, ITestOutputHelper output)
         : base(driver, output)
@@ -48,38 +44,11 @@ public class SelectDevicesForPurchasePageObject : PageObject
         _driver.FindElement(_searchDevicesButton).Click();
     }
 
-    public void ClearFilters()
-    {
-        WaitForBeingClickable(_clearDeviceFiltersButton);
-        _driver.FindElement(_clearDeviceFiltersButton).Click();
-    }
-
     public void AddDevice(string deviceName)
     {
         var addDeviceButton = By.Id($"deviceToBuy_{deviceName}");
         WaitForBeingClickable(addDeviceButton);
         _driver.FindElement(addDeviceButton).Click();
-    }
-
-    public void RemoveDevice(int deviceId)
-    {
-        var removeDeviceButton = By.Id($"removeDevice_{deviceId}");
-        WaitForBeingClickable(removeDeviceButton);
-        _driver.FindElement(removeDeviceButton).Click();
-    }
-
-    public void IncreaseQuantity(int deviceId)
-    {
-        var increaseQuantityButton = By.Id($"increaseQuantity_{deviceId}");
-        WaitForBeingClickable(increaseQuantityButton);
-        _driver.FindElement(increaseQuantityButton).Click();
-    }
-
-    public void DecreaseQuantity(int deviceId)
-    {
-        var decreaseQuantityButton = By.Id($"decreaseQuantity_{deviceId}");
-        WaitForBeingClickable(decreaseQuantityButton);
-        _driver.FindElement(decreaseQuantityButton).Click();
     }
 
     public void ContinuePurchase()
@@ -88,27 +57,11 @@ public class SelectDevicesForPurchasePageObject : PageObject
         _driver.FindElement(_purchaseDevicesButton).Click();
     }
 
-    public bool IsDevicesTableVisible()
-    {
-        return _driver.FindElements(_tableOfDevices).Any();
-    }
-
     public bool IsEmptyCartMessageVisible()
     {
         return _driver.FindElements(_emptyCartMessage).Any();
     }
 
-    public string GetCartTotalQuantity()
-    {
-        WaitForBeingVisible(_cartTotalQuantity);
-        return _driver.FindElement(_cartTotalQuantity).Text;
-    }
-
-    public string GetCartTotalPrice()
-    {
-        WaitForBeingVisible(_cartTotalPrice);
-        return _driver.FindElement(_cartTotalPrice).Text;
-    }
     public void RemoveFirstDeviceFromCart()
     {
         var removeButton = By.CssSelector("button[id^='removeDevice_']");

--- a/test/AppForSEII2526.UIT/Shared/CU_Compras/SelectDevicesForPurchasePageObject.cs
+++ b/test/AppForSEII2526.UIT/Shared/CU_Compras/SelectDevicesForPurchasePageObject.cs
@@ -109,4 +109,17 @@ public class SelectDevicesForPurchasePageObject : PageObject
         WaitForBeingVisible(_cartTotalPrice);
         return _driver.FindElement(_cartTotalPrice).Text;
     }
+    public void RemoveFirstDeviceFromCart()
+    {
+        var removeButton = By.CssSelector("button[id^='removeDevice_']");
+        WaitForBeingClickable(removeButton);
+        _driver.FindElement(removeButton).Click();
+    }
+
+    public void IncreaseFirstDeviceQuantity()
+    {
+        var increaseButton = By.CssSelector("button[id^='increaseQuantity_']");
+        WaitForBeingClickable(increaseButton);
+        _driver.FindElement(increaseButton).Click();
+    }
 }

--- a/test/AppForSEII2526.UIT/Shared/CU_Compras/UCPurchaseDevices_UIT.cs
+++ b/test/AppForSEII2526.UIT/Shared/CU_Compras/UCPurchaseDevices_UIT.cs
@@ -1,0 +1,250 @@
+﻿using AppForSEII2526.UIT.Shared.CU_Compras;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AppForSEII2526.UIT.Shared.CU_Compras;
+
+public class UCPurchaseDevices_UIT : UC_UIT
+{
+    private readonly SelectDevicesForPurchasePageObject selectDevices;
+    private readonly CreatePurchasePageObject createPurchase;
+    private readonly DetailPurchasePageObject detailPurchase;
+
+    private const string deviceName1 = "Galaxy S24";
+    private const string deviceName2 = "iPhone 15";
+    private const string deviceName3 = "Pixel 8";
+
+    private const string color1 = "Blue";
+    private const string color2 = "Black";
+    private const string color3 = "White";
+
+    private const string customerName = "Maria";
+    private const string customerSurname = "Torres";
+    private const string deliveryAddress = "Albacete";
+
+    public UCPurchaseDevices_UIT(ITestOutputHelper output) : base(output)
+    {
+        selectDevices = new SelectDevicesForPurchasePageObject(_driver, _output);
+        createPurchase = new CreatePurchasePageObject(_driver, _output);
+        detailPurchase = new DetailPurchasePageObject(_driver, _output);
+    }
+
+    private void InitialStepsForPurchaseDevices_UIT()
+    {
+        Perform_login("maria@uclm.es", "Aa123456789@");
+
+        Thread.Sleep(500);
+
+        _driver.Navigate().GoToUrl(_URI + "purchase/selectdevicesforpurchase");
+
+        var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(15));
+
+        wait.Until(d =>
+        {
+            var readyState = ((IJavaScriptExecutor)d).ExecuteScript("return document.readyState");
+            return readyState?.ToString() == "complete";
+        });
+
+        wait.Until(d =>
+            d.FindElements(By.Id("searchDevices")).Count > 0 ||
+            d.FindElements(By.Id("TableOfDevices")).Count > 0 ||
+            d.FindElements(By.CssSelector("button[id^='deviceToBuy_']")).Count > 0 ||
+            d.PageSource.ToLower().Contains("comprar dispositivo") ||
+            d.PageSource.ToLower().Contains("no hay dispositivos"));
+
+        Thread.Sleep(1000);
+    }
+
+    [Theory]
+    [Trait("LevelTesting", "Functional Testing")]
+    [InlineData("CreditCard")]
+    [InlineData("PayPal")]
+    public void UC1_BasicFlow_AllPaymentMethods(string paymentMethod)
+    {
+        InitialStepsForPurchaseDevices_UIT();
+
+        selectDevices.AddDevice(deviceName1);
+        selectDevices.ContinuePurchase();
+
+        var waitForm = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+        waitForm.Until(d => d.FindElements(By.Id("purchaseName")).Count > 0);
+
+        createPurchase.FillCustomerData(customerName, customerSurname, deliveryAddress);
+        createPurchase.SelectPaymentMethod(paymentMethod);
+        createPurchase.SavePurchase();
+
+        var waitUrl = new WebDriverWait(_driver, TimeSpan.FromSeconds(15));
+        waitUrl.Until(d => d.Url.ToLower().Contains("detailpurchase"));
+
+        _output.WriteLine($"[{paymentMethod}] URL FINAL: " + _driver.Url);
+
+        Assert.Contains("detailpurchase", _driver.Url.ToLower());
+        Assert.True(detailPurchase.IsLoaded());
+        Assert.Contains(customerName, detailPurchase.GetCustomerName());
+        Assert.Contains(customerSurname, detailPurchase.GetCustomerSurname());
+        Assert.Contains(deliveryAddress, detailPurchase.GetDeliveryAddress());
+        Assert.True(detailPurchase.IsItemsTableVisible());
+    }
+
+    [Fact]
+    [Trait("LevelTesting", "Functional Testing")]
+    public void UC2_1_NoDevicesAvailable()
+    {
+        InitialStepsForPurchaseDevices_UIT();
+
+        selectDevices.SearchByNameAndColor("Dispositivo inexistente", "Color inexistente");
+
+        var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+        wait.Until(d =>
+            d.FindElements(By.Id("noDevicesMessage")).Count > 0 ||
+            d.PageSource.ToLower().Contains("no hay dispositivos"));
+
+        Assert.Contains("no hay dispositivos", _driver.PageSource.ToLower());
+    }
+
+    [Fact]
+    [Trait("LevelTesting", "Functional Testing")]
+    public void UC3_1_FilterByName()
+    {
+        InitialStepsForPurchaseDevices_UIT();
+
+        selectDevices.SearchByName(deviceName1);
+
+        var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+        wait.Until(d => d.PageSource.Contains(deviceName1));
+
+        Assert.Contains(deviceName1, _driver.PageSource);
+        Assert.DoesNotContain(deviceName2, _driver.PageSource);
+    }
+
+    [Fact]
+    [Trait("LevelTesting", "Functional Testing")]
+    public void UC3_2_FilterByColor()
+    {
+        InitialStepsForPurchaseDevices_UIT();
+
+        selectDevices.SearchByColor(color2);
+
+        var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+        wait.Until(d => d.PageSource.Contains(deviceName2));
+
+        Assert.Contains(deviceName2, _driver.PageSource);
+    }
+
+    [Fact]
+    [Trait("LevelTesting", "Functional Testing")]
+    public void UC3_3_FilterByNameAndColor()
+    {
+        InitialStepsForPurchaseDevices_UIT();
+
+        selectDevices.SearchByNameAndColor(deviceName3, color3);
+
+        var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+        wait.Until(d => d.PageSource.Contains(deviceName3));
+
+        Assert.Contains(deviceName3, _driver.PageSource);
+    }
+
+    [Fact]
+    [Trait("LevelTesting", "Functional Testing")]
+    public void UC4_1_ModifyPurchaseCart()
+    {
+        InitialStepsForPurchaseDevices_UIT();
+
+        selectDevices.AddDevice(deviceName1);
+        selectDevices.AddDevice(deviceName2);
+
+        selectDevices.IncreaseFirstDeviceQuantity();
+        selectDevices.RemoveFirstDeviceFromCart();
+
+        selectDevices.ContinuePurchase();
+
+        var waitForm = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+        waitForm.Until(d => d.FindElements(By.Id("purchaseName")).Count > 0);
+
+        Assert.Contains("Cantidad total", createPurchase.GetTotalQuantity());
+        Assert.DoesNotContain(deviceName2, _driver.PageSource);
+    }
+
+    [Fact]
+    [Trait("LevelTesting", "Functional Testing")]
+    public void UC5_1_EmptyCart()
+    {
+        InitialStepsForPurchaseDevices_UIT();
+
+        selectDevices.AddDevice(deviceName1);
+        selectDevices.RemoveFirstDeviceFromCart();
+
+        var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+        wait.Until(d =>
+            d.FindElement(By.Id("purchaseDevicesButton")).GetAttribute("disabled") != null);
+
+        var purchaseButton = _driver.FindElement(By.Id("purchaseDevicesButton"));
+        var isDisabled = purchaseButton.GetAttribute("disabled") != null;
+
+        Assert.True(isDisabled);
+        Assert.True(selectDevices.IsEmptyCartMessageVisible());
+    }
+
+    [Theory]
+    [Trait("LevelTesting", "Functional Testing")]
+    [InlineData("", "Torres", "Albacete", "purchaseNameError")]
+    [InlineData("Maria", "", "Albacete", "purchaseSurnameError")]
+    [InlineData("Maria", "Torres", "", "purchaseDeliveryAddressError")]
+    public void UC6_ValidationErrors(
+        string name,
+        string surname,
+        string address,
+        string expectedErrorId)
+    {
+        InitialStepsForPurchaseDevices_UIT();
+
+        selectDevices.AddDevice(deviceName1);
+        selectDevices.ContinuePurchase();
+
+        var waitForm = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+        waitForm.Until(d => d.FindElements(By.Id("purchaseName")).Count > 0);
+
+        createPurchase.FillCustomerData(name, surname, address);
+        createPurchase.SelectPaymentMethod("CreditCard");
+        createPurchase.SavePurchase();
+
+        var waitError = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+        waitError.Until(d => d.FindElements(By.Id(expectedErrorId)).Any(e => e.Displayed));
+
+        Assert.True(_driver.FindElement(By.Id(expectedErrorId)).Displayed);
+    }
+
+    [Fact]
+    [Trait("LevelTesting", "Functional Testing")]
+    public void UC7_1_ModifySelectedDevicesAndKeepFormData()
+    {
+        InitialStepsForPurchaseDevices_UIT();
+
+        selectDevices.AddDevice(deviceName1);
+        selectDevices.ContinuePurchase();
+
+        var waitForm = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+        waitForm.Until(d => d.FindElements(By.Id("purchaseName")).Count > 0);
+
+        createPurchase.FillCustomerData(customerName, customerSurname, deliveryAddress);
+        createPurchase.SelectPaymentMethod("CreditCard");
+
+        createPurchase.ModifyCart();
+
+        var waitDevices = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+        waitDevices.Until(d => d.FindElements(By.Id("TableOfDevices")).Count > 0);
+
+        selectDevices.AddDevice(deviceName2);
+        selectDevices.ContinuePurchase();
+
+        waitForm.Until(d => d.FindElements(By.Id("purchaseName")).Count > 0);
+
+        Assert.Equal(customerName, _driver.FindElement(By.Id("purchaseName")).GetAttribute("value"));
+        Assert.Equal(customerSurname, _driver.FindElement(By.Id("purchaseSurname")).GetAttribute("value"));
+        Assert.Equal(deliveryAddress, _driver.FindElement(By.Id("purchaseDeliveryAddress")).GetAttribute("value"));
+    }
+}

--- a/test/AppForSEII2526.UIT/Shared/CU_Compras/UCPurchaseDevices_UIT.cs
+++ b/test/AppForSEII2526.UIT/Shared/CU_Compras/UCPurchaseDevices_UIT.cs
@@ -1,9 +1,4 @@
-﻿using AppForSEII2526.UIT.Shared.CU_Compras;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using OpenQA.Selenium;
-using OpenQA.Selenium.Support.UI;
-using Xunit;
-using Xunit.Abstractions;
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace AppForSEII2526.UIT.Shared.CU_Compras;
 
@@ -66,7 +61,7 @@ public class UCPurchaseDevices_UIT : UC_UIT
     {
         InitialStepsForPurchaseDevices_UIT();
 
-        selectDevices.AddDevice(deviceName1);
+        selectDevices.AddDevice(deviceName3);
         selectDevices.ContinuePurchase();
 
         var waitForm = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
@@ -74,10 +69,7 @@ public class UCPurchaseDevices_UIT : UC_UIT
 
         createPurchase.FillCustomerData(customerName, customerSurname, deliveryAddress);
         createPurchase.SelectPaymentMethod(paymentMethod);
-        createPurchase.SavePurchase();
-
-        var waitUrl = new WebDriverWait(_driver, TimeSpan.FromSeconds(15));
-        waitUrl.Until(d => d.Url.ToLower().Contains("detailpurchase"));
+        createPurchase.SavePurchaseAndWaitForDetail();
 
         _output.WriteLine($"[{paymentMethod}] URL FINAL: " + _driver.Url);
 
@@ -87,6 +79,8 @@ public class UCPurchaseDevices_UIT : UC_UIT
         Assert.Contains(customerSurname, detailPurchase.GetCustomerSurname());
         Assert.Contains(deliveryAddress, detailPurchase.GetDeliveryAddress());
         Assert.True(detailPurchase.IsItemsTableVisible());
+        Assert.Contains("Cantidad total", detailPurchase.GetTotalQuantity());
+        Assert.Contains("Precio total", detailPurchase.GetTotalPrice());
     }
 
     [Fact]
@@ -111,13 +105,13 @@ public class UCPurchaseDevices_UIT : UC_UIT
     {
         InitialStepsForPurchaseDevices_UIT();
 
-        selectDevices.SearchByName(deviceName1);
+        selectDevices.SearchByName(deviceName2);
 
-        var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
-        wait.Until(d => d.PageSource.Contains(deviceName1));
+        var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(20));
+        wait.Until(d => d.PageSource.Contains(deviceName2));
 
-        Assert.Contains(deviceName1, _driver.PageSource);
-        Assert.DoesNotContain(deviceName2, _driver.PageSource);
+        Assert.Contains(deviceName2, _driver.PageSource);
+        Assert.DoesNotContain(deviceName1, _driver.PageSource);
     }
 
     [Fact]
@@ -233,12 +227,9 @@ public class UCPurchaseDevices_UIT : UC_UIT
         createPurchase.FillCustomerData(customerName, customerSurname, deliveryAddress);
         createPurchase.SelectPaymentMethod("CreditCard");
 
-        createPurchase.ModifyCart();
+        createPurchase.ModifyCartAndWaitForSelection();
 
-        var waitDevices = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
-        waitDevices.Until(d => d.FindElements(By.Id("TableOfDevices")).Count > 0);
-
-        selectDevices.AddDevice(deviceName2);
+        selectDevices.AddDevice(deviceName3);
         selectDevices.ContinuePurchase();
 
         waitForm.Until(d => d.FindElements(By.Id("purchaseName")).Count > 0);


### PR DESCRIPTION
Closes #158

## Qué cambia

- Añadida la clase `UCPurchaseDevices_UIT` para automatizar el CU Comprar dispositivo.
- Añadidos/ajustados Page Objects de compra:
  - `SelectDevicesForPurchasePageObject`
  - `CreatePurchasePageObject`
  - `DetailPurchasePageObject`
- Automatizado el flujo básico con `CreditCard` y `PayPal`.
- Automatizados flujos alternativos:
  - sin dispositivos disponibles
  - filtros por nombre, color y nombre + color
  - modificación del carrito
  - carrito vacío
  - validaciones de nombre, apellidos y dirección
  - conservación de datos al volver al carrito
- Añadidas esperas explícitas con `WebDriverWait`.
- Limpiados métodos no usados en los Page Objects.

## Cómo se ha probado

```cmd
dotnet test test\AppForSEII2526.UIT\AppForSEII2526.UIT.csproj --filter UCPurchaseDevices_UIT